### PR TITLE
Support passing redis client in settings object

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,8 @@ The `settings` fields are:
   - `host`: string, Redis host.
   - `port`: number, Redis port.
   - `socket`: string, Redis socket to be used instead of a host and port.
+
+  Note that this can also be a node_redis `RedisClient` instance, in which case Bee-Queue will issue normal commands over it. It will `duplicate()` the client for blocking commands and PubSub subscriptions, if enabled. This is advanced usage,
 - `isWorker`: boolean. Disable if this queue will not process jobs.
 - `getEvents`: boolean. Disable if this queue does not need to receive job events.
 - `sendEvents`: boolean. Disable if this worker does not need to send job events back to other queues.
@@ -288,6 +290,7 @@ The `settings` fields are:
 - `activateDelayedJobs`: boolean. Activate delayed jobs once they've passed their `delayUntil` timestamp. Note that this must be enabled on at least one `Queue` instance for the delayed retry strategies (`fixed` and `exponential`) - this will reactivate them after their computed delay.
 - `removeOnSuccess`: boolean. Enable to have this worker automatically remove its successfully completed jobs from Redis, so as to keep memory usage down.
 - `removeOnFailure`: boolean. Enable to have this worker automatically remove its failed jobs from Redis, so as to keep memory usage down. This will not remove jobs that are set to retry unless they fail all their retries.
+- `quitCommandClient`: boolean. Whether to `QUIT` the redis command client (the client it sends normal operations over) when `Queue#close` is called. This defaults to `true` for normal usage, and `false` if an existing `RedisClient` object was provided to the `redis` option.
 - `redisScanCount`: number. For setting the value of the `SSCAN` Redis command used in `Queue#getJobs` for succeeded and failed job types.
 
 ### Properties

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -19,6 +19,9 @@ module.exports = {
   removeOnFailure: false,
   redisScanCount: 100,
 
+  // quitCommandClient is dependent on whether the redis setting was an actual
+  // redis client, or just configuration options to create such a client.
+
   // Method-specific defaults.
   '#close': {
     timeout: 5000

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -30,6 +30,7 @@ class Queue extends Emitter {
     settings = settings || {};
     this.settings = {
       redis: settings.redis || {},
+      quitCommandClient: settings.quitCommandClient,
       keyPrefix: (settings.prefix || defaults.prefix) + ':' + this.name + ':'
     };
 
@@ -49,6 +50,12 @@ class Queue extends Emitter {
       });
     }
 
+    // By default, if we're given a redis client and no additional instructions,
+    // don't quit the connection on Queue#close.
+    if (typeof this.settings.quitCommandClient !== 'boolean') {
+      this.settings.quitCommandClient = !redis.isClient(this.settings.redis);
+    }
+
     // To avoid changing the hidden class of the Queue.
     this._delayedTimer = this.settings.activateDelayedJobs
       ? new EagerTimer(this.settings.nearTermWindow)
@@ -57,8 +64,8 @@ class Queue extends Emitter {
       this._delayedTimer.on('trigger', this._activateDelayed.bind(this));
     }
 
-    const makeClient = (clientName) => {
-      return redis.createClient(this.settings.redis)
+    const makeClient = (clientName, createNew) => {
+      return redis.createClient(this.settings.redis, createNew)
         .then((client) => {
           client.on('error', this.emit.bind(this, 'error'));
           return this[clientName] = client;
@@ -68,7 +75,7 @@ class Queue extends Emitter {
     let eventsPromise = null;
 
     if (this.settings.getEvents || this.settings.activateDelayedJobs) {
-      eventsPromise = makeClient('eclient').then(() => {
+      eventsPromise = makeClient('eclient', true).then(() => {
         this.eclient.on('message', this._onMessage.bind(this));
         const channels = [];
         if (this.settings.getEvents) {
@@ -91,8 +98,8 @@ class Queue extends Emitter {
     // bclient and eclient/subscribe if they're needed.
     this._ready = Promise.all([
       // Make the clients
-      makeClient('client'),
-      this.settings.isWorker ? makeClient('bclient') : null,
+      makeClient('client', false),
+      this.settings.isWorker ? makeClient('bclient', true) : null,
       eventsPromise
     ]).then(() => {
       if (this.settings.ensureScripts) {
@@ -184,7 +191,10 @@ class Queue extends Emitter {
     const cleanup = () => {
       this._isClosed = true;
 
-      const clients = [this.client];
+      const clients = [];
+      if (this.settings.quitCommandClient) {
+        clients.push(this.client);
+      }
       if (this.settings.getEvents) {
         clients.push(this.eclient);
       }
@@ -200,7 +210,7 @@ class Queue extends Emitter {
       // Stop the blocking connection, ensures that we don't accept additional
       // jobs while waiting for the ongoing jobs to terminate.
       if (this.settings.isWorker) {
-        this.bclient.end(true);
+        redis.disconnect(this.bclient);
       }
 
       // Wait for all the jobs to complete. Ignore job errors during shutdown.
@@ -421,7 +431,7 @@ class Queue extends Emitter {
       // returned the job id.
       return Job.fromId(this, jobId);
     }, (err) => {
-      if (err.name === 'AbortError' && this.paused) {
+      if (redis.isAbortError(err) && this.paused) {
         return null;
       }
       throw err;
@@ -720,7 +730,7 @@ class Queue extends Emitter {
         this._delayedTimer.schedule(parseInt(nextOpportunity, 10));
       }, /* istanbul ignore next */ (err) => {
         // Handle aborted redis connections.
-        if (err.name === 'AbortError') {
+        if (redis.isAbortError(err)) {
           if (this.paused) return;
           // Retry.
           return this._activateDelayed();

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -3,17 +3,70 @@
 const redis = require('redis');
 const helpers = require('./helpers');
 
-function createClient(settings) {
-  // node_redis mutates the options object we provide it.
-  if (settings && typeof settings === 'object') {
-    settings = Object.assign({}, settings);
-  }
+function createClient(settings, createNew) {
+  let client;
+  if (isClient(settings)) {
+    // We assume it's a redis client from either node_redis or ioredis.
+    client = settings;
 
-  const client = redis.createClient(settings);
+    if (createNew) {
+      // Both node_redis and ioredis support the duplicate method, which creates
+      // a new redis client with the same configuration.
+      client = client.duplicate();
+    } else if (isReady(client)) {
+      // If we were given a redis client, and we don't want to clone it (to
+      // enable connection sharing between Queue instances), and it's already
+      // ready, then just return it.
+      return Promise.resolve(client);
+    } // otherwise, we wait for the client to be in the ready state.
+  } else {
+    // node_redis mutates the options object we provide it, so we clone the
+    // settings first.
+    if (typeof settings === 'object') {
+      settings = Object.assign({}, settings);
+    }
+
+    client = redis.createClient(settings);
+  }
 
   // Wait for the client to be ready, then resolve with the client itself.
   return helpers.waitOn(client, 'ready', true)
     .then(() => client);
 }
 
+function disconnect(client) {
+  // Redis#end is deprecated for ioredis.
+  /* istanbul ignore if: this is only for ioredis */
+  if (client.disconnect) {
+    client.disconnect();
+  } else {
+    // true indicates that it should invoke all pending callbacks with an
+    // AbortError; we need this behavior.
+    client.end(true);
+  }
+}
+
+function isAbortError(err) {
+  // node_redis has a designated class for abort errors, but ioredis just has
+  // a constant message defined in a utils file.
+  return err.name === 'AbortError' ||
+    /* istanbul ignore next: this is only for ioredis */
+    err.message === 'Connection is closed.';
+}
+
+function isClient(object) {
+  if (!object || typeof object !== 'object') return false;
+  const name = object.constructor.name;
+  return name === 'Redis' || name === 'RedisClient';
+}
+
+function isReady(client) {
+  // node_redis has a ready property, ioredis has a status property.
+  return client.ready || client.status === 'ready';
+}
+
 exports.createClient = createClient;
+exports.disconnect = disconnect;
+exports.isAbortError = isAbortError;
+exports.isClient = isClient;
+exports.isReady = isReady;

--- a/test/queue-test.js
+++ b/test/queue-test.js
@@ -7,6 +7,7 @@ import sinon from 'sinon';
 import {promisify} from 'promise-callbacks';
 
 import redis from '../lib/redis';
+import {createClient} from 'redis';
 
 // A promise-based barrier.
 function reef(n = 1) {
@@ -165,15 +166,22 @@ describe('Queue', (it) => {
 
         await queue.ready();
 
-        t.true(queue.client.ready);
-        t.true(queue.bclient.ready);
-        t.true(queue.eclient.ready);
+        t.true(redis.isReady(queue.client));
+        t.true(redis.isReady(queue.bclient));
+        t.true(redis.isReady(queue.eclient));
 
         await queue.close();
 
-        t.false(queue.client.ready);
-        t.false(queue.bclient.ready);
-        t.false(queue.eclient.ready);
+        // ioredis closes the connection some time after the quit response has
+        // been received.
+        await Promise.all([
+          redis.isReady(queue.client) && helpers.waitOn(queue.client, 'close'),
+          redis.isReady(queue.bclient) && helpers.waitOn(queue.bclient, 'close'),
+          redis.isReady(queue.eclient) && helpers.waitOn(queue.eclient, 'close'),
+        ]);
+
+        t.false(redis.isReady(queue.client));
+        t.false(redis.isReady(queue.eclient));
       });
 
       it.cb('should support callbacks', (t) => {
@@ -370,6 +378,31 @@ describe('Queue', (it) => {
 
         t.context.handleErrors(t);
       });
+
+      it('should not quit the command client by default if given in settings', async (t) => {
+        const client = await redis.createClient();
+
+        sinon.spy(client, 'quit');
+
+        let queue = t.context.makeQueue({
+          redis: client
+        });
+
+        await queue.close();
+
+        t.true(client.ready);
+        t.false(client.quit.called);
+
+        queue = t.context.makeQueue({
+          redis: client,
+          quitCommandClient: true
+        });
+
+        await queue.close();
+
+        t.false(client.ready);
+        t.true(client.quit.called);
+      });
     });
 
     it('should recover from a connection loss', async (t) => {
@@ -392,6 +425,7 @@ describe('Queue', (it) => {
       // Not called at all yet because queue.process uses setImmediate.
       t.is(jobSpy.callCount, 0);
 
+      // Override _waitForJob.
       const waitJob = queue._waitForJob, wait = helpers.deferred();
       let waitDone = wait.defer();
       queue._waitForJob = function (...args) {
@@ -404,10 +438,12 @@ describe('Queue', (it) => {
 
       await wait;
 
+      const errored = helpers.waitOn(queue, 'error');
+
       queue.bclient.stream.destroy();
 
-      const err = await helpers.waitOn(queue, 'error');
-      t.is(err.name, 'AbortError');
+      const err = await errored;
+      t.true(redis.isAbortError(err));
 
       queue.createJob({foo: 'bar'}).save();
 
@@ -458,6 +494,34 @@ describe('Queue', (it) => {
 
       t.is(queue.client.connection_options.host, '127.0.0.1');
       t.is(queue.bclient, null);
+    });
+
+    it('should create a Queue with an existing redis instance', async (t) => {
+      const client = await redis.createClient();
+
+      const queue = t.context.makeQueue({
+        redis: client
+      });
+
+      await queue.createJob().save();
+
+      t.is(queue.client, client);
+      t.not(queue.eclient, client);
+
+      await queue.close();
+
+      t.true(client.ready);
+      t.false(queue.eclient.ready);
+    });
+
+    it('should create a Queue with a connecting redis instance', async (t) => {
+      const client = createClient();
+
+      const queue = t.context.makeQueue({
+        redis: client
+      });
+
+      await t.notThrows(queue.createJob().save());
     });
   });
 


### PR DESCRIPTION
This allows client sharing between multiple Queue instances, or other uses.

It also begins to add support for ioredis (cc #16 and #21). We might consider supporting both, though there are some major inconsistencies between the two libraries, such as the multi-exec callback form.