### PR TITLE
fix Bluebird promise warning spam

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -686,7 +686,7 @@ class Queue extends Emitter {
           // If it's not the first call, and a callback is not defined, then we
           // must emit errors to avoid unnecessary unhandled rejections.
           /* istanbul ignore next: these are only redis and connection errors */
-          postStalled.catch(cb ? (err) => this.emit('error', err) : null);
+          postStalled.catch(cb ? (err) => this.emit('error', err) : () => {});
         }, interval);
       });
     }


### PR DESCRIPTION

with the latest release I got a loads of warnings like this: 
```js
(node:20972) Warning: .then() only accepts functions but was passed: [object Undefined], [object Null]
```

Few minutes diving into this, it looks like bluebirdjs is printing warnings when you pass `null` in a chain `Promise.reject().catch(null)`.

