### PR TITLE
Typescript definition fix

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+import { ClientOpts } from 'redis';
+
 declare class BeeQueue {
   name: string;
   keyPrefix: string;
@@ -9,7 +11,7 @@ declare class BeeQueue {
 
   on(ev: "ready",     fn: () => void): this;
   on(ev: "error",     fn: (err: Error) => void): this;
-  on(ev: "succeeded", fn: (job: BeeQueue.Job, err: Error) => void): this;
+  on(ev: "succeeded", fn: (job: BeeQueue.Job, result: any) => void): this;
   on(ev: "retrying",  fn: (job: BeeQueue.Job, err: Error) => void): this;
   on(ev: "failed",    fn: (job: BeeQueue.Job, err: Error) => void): this;
   on(ev: "stalled",   fn: (jobId: string) => void): this;
@@ -52,15 +54,7 @@ declare namespace BeeQueue {
     stallInterval?: number,
     nearTermWindow?: number,
     delayedDebounce?: number,
-    redis?: ({
-      host: string
-      port?: number
-    } | {
-      socket: string;
-    }) & {
-      db?: number;
-      options?: any; 
-    },
+    redis?: ClientOpts,
     isWorker?: boolean,
     getEvents?: boolean,
     sendEvents?: boolean,


### PR DESCRIPTION
This pull request fixes two issues in the index.d.ts for the Typescript definitions.

1. The 'succeeded' event passed an error instead of a result. If the handler function ends with an error, the 'retrying'/'error' event will be called and not the 'succeeded'. 
The fix just changed the type from _Error_ to _any_.

2. The 'options' parameter in the BeeQueue constructor takes optionally a [Redis-options object](https://github.com/NodeRedis/node_redis#rediscreateclient). In the original implementation, you were very limited adding the Redis options. E.g. it was not possible to provide a Redis password which is essential in many cases. 
The fix imports the original Redis options type _ClientOpts_ from the Redis module and uses it as type for the constructor parameter 'options.redis'
  