### PR TITLE
Change travis to test Node 4, 6, 8, 9 latests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: node_js
 node_js:
   - 4
-  - 6.9.1
   - 6
-  - 7.6.0
-  - 7
-  - node
+  - 8
+  - 9
 services: redis
 # this runs eslint, runs the tests, instruments their coverage, and
 # publishes it to coveralls.io


### PR DESCRIPTION
Hopefully this will get rid of whatever strange issue #89 ran into with CI testing v6.9.1, and it'll make us test on Node 9.