### PR TITLE
fix: DoneCallback.result is optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -109,7 +109,7 @@ declare namespace BeeQueue {
     newestJob?: string;
   }
 
-  type DoneCallback<T> = (error: Error | null, result: T) => void;
+  type DoneCallback<T> = (error: Error | null, result?: T) => void;
 }
 
 export = BeeQueue;


### PR DESCRIPTION
e.g. `done(error)`