### PR TITLE
Custom job events with job.publish(name, data)

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,6 +741,30 @@ queue.process(async (job, done) => {
 
 Reports job progress when called within a handler function. Causes a `progress` event to be emitted. Does not persist the progress to Redis, but will store it on `job.progress`, and if other `Queue`s have `storeJobs` and `getEvents` enabled, then the `progress` will end up on all corresponding job instances.
 
+### Job#publish(name,data)
+
+```js
+const job = queue.createJob({...}).save();
+
+job.on('found-something', (data) => {
+  console.log(`Job ${job.id} updated with:`, data);
+});
+
+queue.process(async (job) => {
+
+  // do some work
+
+  job.publish('found-something', {msg:"found abc"});
+
+  // do some work
+
+  job.publish('found-something', {msg:"found xyz"});
+
+});
+```
+
+While processing a job you can send custom events back e.g. for specific log information etc.
+
 #### Job#remove([cb])
 
 ```js

--- a/lib/job.js
+++ b/lib/job.js
@@ -161,6 +161,24 @@ class Job extends Emitter {
     return promise;
   }
 
+  publish(name, data) {
+    // publish a custom event via the pubsub
+
+    const promise = this.queue._commandable().then((client) => {
+      const publishPromise = helpers.deferred();
+      const payload = JSON.stringify({
+        id: this.id,
+        event: name,
+        data
+      });
+      client.publish(this.queue.toKey('events'), payload,
+        publishPromise.defer());
+      return publishPromise;
+    });
+
+    return promise;
+  }
+
   remove(cb) {
     const promise = this.queue.removeJob(this.id).then(() => this);
     if (cb) helpers.asCallback(promise, cb);

--- a/test/job-test.js
+++ b/test/job-test.js
@@ -131,6 +131,22 @@ describe('Job', (it) => {
     });
   });
 
+  it.describe('Custom event', (it) => {
+    it.cb('let you emit & subscribe, passing data', (t) => {
+      const {makeJob} = t.context;
+
+      makeJob().then((job) => {
+        job.on('custom-event-1', (data) => {
+          if (! data || data.hello !== 'world') {
+            throw new Error('failed to recieve correct data');
+          }
+          t.end();
+        });
+        job.publish('custom-event-1', {hello: 'world'});
+      });
+    });
+  });
+
   it.describe('Remove', (it) => {
     it('removes the job from redis', async (t) => {
       const {queue, makeJob} = t.context;


### PR DESCRIPTION
Ref #107.

Created a job.publish() method instead of .emit as originally proposed as the job class extends EventEmiiter and so already had an emit method. *(happy to rename the method to whatever fits best though :+1:)*

README updated & test added to maintain coverage.

One use case for this would be if you were performing a long task such as reading lines in a large file you could publish as you found specific strings you were hunting for. Or if you were running a crawl via this you could then publish events about other urls discovered etc.