### PR TITLE
Added NOTE to set activateDelayedJobs of a Queue to be able to use the Job#backoff functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,6 +665,8 @@ Stored in `job.options.retries` and decremented each time the job is retried.
 
 Defaults to 0.
 
+_N.B.: bee-queue's retries jobs by re-enqueuing failed jobs as delayed jobs. This means you need to enable `activateDelayedJobs` on any queue that uses retry/backoff functionality._
+
 #### Job#backoff(strategy, delayFactor)
 
 ```js
@@ -685,6 +687,8 @@ Sets the backoff policy when handling retries.
 This setting is stored in `job.options.backoff` as `{strategy, delay}`.
 
 Defaults to `'immediate'`.
+
+_N.B.: bee-queue's retries jobs by re-enqueuing failed jobs as delayed jobs. This means you need to enable `activateDelayedJobs` on any queue that uses retry/backoff functionality._
 
 #### Job#delayUntil(date|timestamp)
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "ava": "^0.21.0",
     "ava-spec": "^1.1.0",
     "coveralls": "^2.11.2",
-    "eslint": ">= 3",
+    "eslint": "^3",
     "lolex": "^2.0.0",
     "nyc": "^11.0.3",
     "sandboxed-module": "^2.0.3",


### PR DESCRIPTION
Just a little documentation improvement. I spent hour(s) to make the Job#backoff work on my setup. Turned out I just missed a little detail.  I even created a hackish way for the retry and backoff strategy