### PR TITLE
fix(backoff): allow no delay arg when setting immediate strategy

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -85,7 +85,7 @@ declare namespace BeeQueue {
 
     setId(id: string): this;
     retries(n: number): this;
-    backoff(strategy: "immediate" | "fixed" | "exponential", delayFactor: number): this;
+    backoff(strategy: "immediate" | "fixed" | "exponential", delayFactor?: number): this;
     delayUntil(dateOrTimestamp: Date | number): this;
     timeout(milliseconds: number): this;
     save(): Promise<this>;

--- a/lib/job.js
+++ b/lib/job.js
@@ -124,7 +124,9 @@ class Job extends Emitter {
     if (!strategies.has(strategy)) {
       throw new Error('unknown strategy');
     }
-    if (!Number.isSafeInteger(delay) || delay <= 0) {
+
+    const isInvalidDelay = !Number.isSafeInteger(delay) || delay <= 0;
+    if (strategy !== 'immediate' && isInvalidDelay) {
       throw new Error('delay must be a positive integer');
     }
     this.options.backoff = {


### PR DESCRIPTION
Per [the documentation](https://github.com/bee-queue/bee-queue#jobbackoffstrategy-delayfactor) you should be able to call `job.backoff('immediate')` to set an immediate backoff strategy for retried jobs. However, the `backoff` method explicitly disallowed this by checking for `Number.isSafeInteger(undefined)` which returns false. This means you currently cannot specify an immediate backoff strategy without also specifying a positive delay value.

To fix this, only check for valid integers when the strategy is not `immediate`.