### PR TITLE
add note to README about done() and process passed async function

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ queue.on('failed', (job, err) => {
 });
 ```
 
-This queue has processed `job`, but its handler reported a failure either by rejecting its returned Promise, or by calling `done(err)`.
+This queue has processed `job`, but its handler reported a failure either by rejecting its returned Promise, or by calling `done(err)`. Note that if you pass an async function to process, you must reject it by returning `Promise.reject(...)` or throwing an exception ([done does not apply](https://github.com/bee-queue/bee-queue/issues/95)).
 
 #### stalled
 


### PR DESCRIPTION
I found this aspect of how bee-queue works confusing. It makes sense after reading #95 however it would be great to call it out in the README.