### PR TITLE
remove node 4 test from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - 4
   - 6
   - 8
   - 9


### PR DESCRIPTION
Travis CI is failing with Node 4 due to using destructuring:

```log
/home/travis/build/bee-queue/bee-queue/node_modules/eslint/lib/cli-engine.js:612
            const { result, config } = processFile(fileInfo.filename, configHelper, options, this.linter);
                  ^
SyntaxError: Unexpected token {
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:373:25)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/home/travis/build/bee-queue/bee-queue/node_modules/eslint/lib/cli.js:21:17)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
```

[Node 4 reached end-of-life on 2018-04-30](https://github.com/nodejs/Release/blob/643af71ee8365efbdccaa134690425ea05931279/README.md#release-schedule).