### PR TITLE
If the brpoplpush commands fails, wait before retrying

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -18,6 +18,8 @@ module.exports = {
   removeOnSuccess: false,
   removeOnFailure: false,
   redisScanCount: 100,
+  // first retry period after a brpoplpush failure, backoff is exponential
+  initialRedisFailureRetryDelay: 1000,
 
   // quitCommandClient is dependent on whether the redis setting was an actual
   // redis client, or just configuration options to create such a client.

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -493,12 +493,27 @@ class Queue extends Emitter {
           // removed the job before processing can take place, but after the
           // brpoplpush has returned the job id.
           Job.fromId(this, jobId),
-        (err) =>
-          redis.isAbortError(err) && this.paused ? null : Promise.reject(err)
+        (err) => {
+          if (redis.isAbortError(err) && this.paused) {
+            return null;
+          }
+
+          this.emit('error', err);
+
+          // Retry the brpoplpush after a delay
+          this._redisFailureRetryDelay = this._redisFailureRetryDelay
+            ? this._redisFailureRetryDelay * 2
+            : this.settings.initialRedisFailureRetryDelay;
+
+          return helpers
+            .delay(this._redisFailureRetryDelay)
+            .then(() => this._waitForJob());
+        }
       );
   }
 
   _getNextJob() {
+    this._redisFailureRetryDelay = 0;
     // Under normal calling conditions, commandable will not reject because we
     // will have just checked paused in Queue#process.
     return this._commandable(true).then(() => this._waitForJob());

--- a/test/queue-test.js
+++ b/test/queue-test.js
@@ -548,7 +548,7 @@ describe('Queue', (it) => {
         },
       });
 
-      const jobSpy = sinon.spy(queue, '_getNextJob');
+      const jobSpy = sinon.spy(queue, '_waitForJob');
 
       queue.process(async (job) => {
         t.is(job.data.foo, 'bar');


### PR DESCRIPTION
The current behaviour is to retry as fast as possible, leading to a spam of commands and error messages if the redis instance is for example unavailable for a brief period. It seems more sensible to take a bit more care in retrying.