### PR TITLE
feat: recurring jobs

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -35,15 +35,24 @@ class Job extends Emitter {
     data = JSON.parse(data);
     const job = new Job(queue, jobId, data.data, data.options);
     job.status = data.status;
+    if (data.count) {
+      job.count = data.count;
+    }
     return job;
   }
 
   toData() {
-    return JSON.stringify({
+    const data = {
       data: this.data,
       options: this.options,
       status: this.status
-    });
+    };
+
+    if (this.count) {
+      data.count = this.count;
+    }
+
+    return JSON.stringify(data);
   }
 
   save(cb) {
@@ -84,7 +93,35 @@ class Job extends Emitter {
   }
 
   setId(id) {
+    if (id.substr(0,2) === 'r:') {
+      throw new Error('IDs starting with r: are reserved for recurring jobs.');
+    }
     this.id = id;
+    return this;
+  }
+
+  setInterval(interval) {
+    if (typeof interval === 'string') {
+      const multiplier = {'s': 1000, 'm': 60000, 'h': 3600000, 'd': 86400000};
+      if (!multiplier[interval.slice(-1)]) {
+        throw new Error('only valid suffixes are s, m, h, and d.');
+      }
+      interval = parseInt(parseFloat(interval) *
+                          multiplier[interval.slice(-1)]);
+    }
+    if (!Number.isSafeInteger(interval) || interval <= 0) {
+      throw new Error('interval must be a positive integer');
+    }
+    if (this.queue.settings.removeOnSuccess
+      || this.queue.settings.removeOnFailure) {
+      throw new Error('Recurring jobs can not be removed OnSuccess/OnFailure.');
+    }
+    this.id = this.id || '';
+    if (this.id.indexOf(':') >= 0) {
+      throw new Error('ID can not have a colon');
+    }
+    this.id = 'r:' + interval + ':' + this.id;
+    this.options.delay = this.options.delay || Date.now() + 1;
     return this;
   }
 

--- a/lib/lua/addDelayedJob.lua
+++ b/lib/lua/addDelayedJob.lua
@@ -12,6 +12,12 @@ local jobId = ARGV[1]
 if jobId == "" then
   jobId = "" .. redis.call("incr", KEYS[1])
 end
+if string.sub(jobId, 1, 2) == "r:" then
+  local id = string.gmatch(jobId, "[^:]*$")()
+  if id == "" then
+    jobId = jobId .. redis.call("incr", KEYS[1])
+  end
+end
 if redis.call("hexists", KEYS[2], jobId) == 1 then return nil end
 redis.call("hset", KEYS[2], jobId, ARGV[2])
 redis.call("zadd", KEYS[3], tonumber(ARGV[3]), jobId)

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -518,6 +518,10 @@ class Queue extends Emitter {
       data: err ? err.message : data
     };
 
+    if (job.id.substr(0,2) === 'r:') {
+      job.count = job.count || 0;
+      ++job.count;
+    }
     if (err) {
       const errInfo = err.stack || err.message || err;
       job.options.stacktraces.unshift(errInfo);


### PR DESCRIPTION
This feature was requested frequently so I decided to add it.

I'm prefixing my key with `r:[ms]:` and inside `raiseDelayedJobs.lua`, pre-emptively schedule such keys for next run. 

I keep a `.count` for number of times this has been run as well, which could come in handy.

To stop the job you'd simply call remove.