### PR TITLE
Delay failed jobs on handled worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,8 @@ const queue = new Queue('test', {
   activateDelayedJobs: false,
   removeOnSuccess: false,
   removeOnFailure: false,
-  redisScanCount: 100
+  redisScanCount: 100,
+  delayFailedJobsByWorker: 0
 });
 ```
 
@@ -281,6 +282,7 @@ The `settings` fields are:
 - `removeOnFailure`: boolean. Enable to have this worker automatically remove its failed jobs from Redis, so as to keep memory usage down. This will not remove jobs that are set to retry unless they fail all their retries.
 - `quitCommandClient`: boolean. Whether to `QUIT` the redis command client (the client it sends normal operations over) when `Queue#close` is called. This defaults to `true` for normal usage, and `false` if an existing `RedisClient` object was provided to the `redis` option.
 - `redisScanCount`: number. For setting the value of the `SSCAN` Redis command used in `Queue#getJobs` for succeeded and failed job types.
+- `delayFailedJobsByWorker`: number. Delay before a failed job can be retried by the same worker.
 
 ### Properties
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -67,7 +67,8 @@ declare namespace BeeQueue {
     removeOnSuccess?: boolean,
     removeOnFailure?: boolean,
     quitCommandClient?: boolean;
-    redisScanCount?: number
+    redisScanCount?: number,
+    delayFailedJobsByWorker: number
   }
 
   interface Job {

--- a/index.d.ts
+++ b/index.d.ts
@@ -68,7 +68,7 @@ declare namespace BeeQueue {
     removeOnFailure?: boolean,
     quitCommandClient?: boolean;
     redisScanCount?: number,
-    delayFailedJobsByWorker: number
+    delayFailedJobsByWorker?: number
   }
 
   interface Job {

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -18,6 +18,7 @@ module.exports = {
   removeOnSuccess: false,
   removeOnFailure: false,
   redisScanCount: 100,
+  delayFailedJobsByWorker: 0,
 
   // quitCommandClient is dependent on whether the redis setting was an actual
   // redis client, or just configuration options to create such a client.

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -20,6 +20,9 @@ class Queue extends Emitter {
     this.activeJobs = new Set();
     this.checkTimer = null;
 
+    // map of failed jobs on this worker instance
+    this.failedJobs = new Map();
+
     this._closed = null;
     this._isClosed = false;
 
@@ -425,7 +428,28 @@ class Queue extends Emitter {
     this.bclient.brpoplpush(this.toKey('waiting'), this.toKey('active'), 0,
       idPromise.defer());
 
-    return idPromise.then((jobId) => {
+    return idPromise.then(jobId => {
+      if (this.settings.delayFailedJobsByWorker > 0) {
+        // Requeue if the job previously failed on this worker
+        // during the last `delayFailedJobsByWorker` ms
+        const lastFailed = this.failedJobs.get(jobId);
+        if (Date.now() - lastFailed < this.settings.delayFailedJobsByWorker) {
+          const requeueJob = () => {
+            const requeuePromise = helpers.deferred();
+            const multi = this.client.multi();
+            multi.lrem(this.toKey('active'), 0, jobId);
+            multi.lpush(this.toKey('waiting'), jobId);
+            multi.exec(requeuePromise.defer());
+            return requeuePromise;
+          };
+          return requeueJob().then(() => null);
+        }
+      }
+      return jobId;
+    }).then((jobId) => {
+      if (jobId == null) {
+        return null;
+      }
       // Note that the job may be null in the case that the client has removed
       // the job before processing can take place, but after the brpoplpush has
       // returned the job id.
@@ -519,6 +543,8 @@ class Queue extends Emitter {
     };
 
     if (err) {
+      this.failedJobs.set(job.id, Date.now());
+
       const errInfo = err.stack || err.message || err;
       job.options.stacktraces.unshift(errInfo);
 


### PR DESCRIPTION
Add queue setting to prevent a failed job to be scheduled on the same
worker for `delayFailedJobsByWorker` ms.
Disabled by default.