### PR TITLE
fix(types): account for Queue.close(timeout)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -41,8 +41,9 @@ declare class BeeQueue {
   checkHealth(): Promise<BeeQueue.HealthCheckResult>;
   checkHealth(cb: (counts: BeeQueue.HealthCheckResult) => void): void;
 
-  close(): Promise<void>;
   close(cb: () => void): void;
+  close(timeout?: number): Promise<void>;
+  close(timeout: number, cb: () => void): void;
 
   removeJob(jobId: string): Promise<void>;
   removeJob(jobId: string, cb: () => void): void

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,8 +42,8 @@ declare class BeeQueue {
   checkHealth(cb: (counts: BeeQueue.HealthCheckResult) => void): void;
 
   close(cb: () => void): void;
-  close(timeout?: number): Promise<void>;
-  close(timeout: number, cb: () => void): void;
+  close(timeout?: number | null): Promise<void>;
+  close(timeout: number | undefined | null, cb: () => void): void;
 
   removeJob(jobId: string): Promise<void>;
   removeJob(jobId: string, cb: () => void): void


### PR DESCRIPTION
These types support all four call signatures:

```
close(): Promise<void>
close(timeout: number): Promise<void>;

close(cb: () => void): void;
close(timeout: number, cb: () => void): void;
```