### PR TITLE
fix(backoff): no delay arg when setting immediate strategy, add test

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -124,7 +124,9 @@ class Job extends Emitter {
     if (!strategies.has(strategy)) {
       throw new Error('unknown strategy');
     }
-    if (!Number.isSafeInteger(delay) || delay <= 0) {
+    if (strategy === 'immediate') {
+      delay = undefined;
+    } else if (!Number.isSafeInteger(delay) || delay <= 0) {
       throw new Error('delay must be a positive integer');
     }
     this.options.backoff = {


### PR DESCRIPTION
This fixes and tests a minor problem mentioned in #184 

This won't break code that has worked around the problem by providing a delay argument to the immediate strategy.