### PR TITLE
fix(queue): emit retrying Queue Local Event instead of failed

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -569,7 +569,7 @@ class Queue extends Emitter {
     const promise = helpers.deferred();
     multi.exec(promise.defer());
 
-    return promise.then(() => [status, result]);
+    return promise.then(() => [job.status, result]);
   }
 
   process(concurrency, handler) {
@@ -643,7 +643,7 @@ class Queue extends Emitter {
 
           /* istanbul ignore else */
           if (results) {
-            const status = results[0], result = results[1];
+            const [status, result] = results;
             this.emit(status, job, result);
           }
         });

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -643,7 +643,7 @@ class Queue extends Emitter {
 
           /* istanbul ignore else */
           if (results) {
-            const [status, result] = results;
+            const status = results[0], result = results[1];
             this.emit(status, job, result);
           }
         });

--- a/test/queue-test.js
+++ b/test/queue-test.js
@@ -654,8 +654,11 @@ describe('Queue', (it) => {
       const retriedJob = await helpers.waitOn(queue, 'retrying');
       t.is(retriedJob.id, job.id);
 
-      const counts = await queue.checkHealth();
       // job fails after the 1 retry
+      const failedJob = await helpers.waitOn(queue, 'failed');
+      t.is(failedJob.id, job.id);
+
+      const counts = await queue.checkHealth();
       t.is(counts.failed, 1);
     });
 

--- a/test/queue-test.js
+++ b/test/queue-test.js
@@ -1212,7 +1212,7 @@ describe('Queue', (it) => {
         t.is(err.message, failMsg);
       });
 
-      queue.on('failed', (job, err) => {
+      queue.on('failed', () => {
         t.fail('unexpected queue failed message');
       });
 

--- a/test/queue-test.js
+++ b/test/queue-test.js
@@ -1267,7 +1267,7 @@ describe('Queue', (it) => {
         t.is(job.data.foo, 'bar');
       });
 
-      queue.on('failed', (job, err) => {
+      queue.on('failed', () => {
         t.fail('unexpected queue failed message');
       });
 


### PR DESCRIPTION
This fixes the problem reported in #184 

This fix could conceivably break code that has worked around the problem, e.g. by looking at `job.options.retries` or `job.status` in their queue failed handler...