### PR TITLE
fix(job.id): Use unique hex string for job id to avoid a race condition

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -6,6 +6,13 @@ function has(object, name) {
   return hasOwn.call(object, name);
 }
 
+// A simple way to get 13 statistically random hex digits, not cryptographic
+const MAX_SAFE_NYBBLE = 13; // low-order 52 bits of double mantissa's 53 bits
+const randomHex13 = () => Math.floor(Math.random() * Number.MAX_SAFE_INTEGER)
+  .toString(16)
+  .padStart(MAX_SAFE_NYBBLE, '0')
+  .slice(-MAX_SAFE_NYBBLE);
+
 const promiseUtils = require('promise-callbacks');
 
 module.exports = {
@@ -16,4 +23,5 @@ module.exports = {
   withTimeout: promiseUtils.withTimeout,
   wrapAsync: promiseUtils.wrapAsync,
   has,
+  randomHex13,
 };

--- a/lib/job.js
+++ b/lib/job.js
@@ -49,35 +49,38 @@ class Job extends Emitter {
   save(cb) {
     const toKey = this.queue.toKey.bind(this.queue);
 
+    if (!this.id) {
+      this.id = helpers.randomHex13();
+    }
+
+    // We add to the stored-jobs set before addJob (or addDelayedJob) so that
+    // this job is already in the queue's map for the rare case of the job
+    // getting popped off 'waiting', completing, and making callbacks (which use
+    // the map) all before the _evalScript promise has resolved.
+    if (this.queue.settings.storeJobs && !this.queue.jobs.has(this.id)) {
+      this.queue.jobs.set(this.id, this);
+    }
+
     let promise;
     if (this.options.delay) {
       promise = this.queue._evalScript('addDelayedJob', 4,
         toKey('id'), toKey('jobs'), toKey('delayed'), toKey('earlierDelayed'),
-        this.id || '', this.toData(), this.options.delay);
+        this.id, this.toData(), this.options.delay);
 
       if (this.queue.settings.activateDelayedJobs) {
         promise = promise.then((jobId) => {
-          // Only reschedule if the job was actually created.
+          // Only reschedule if a new job was actually created.
           if (jobId) {
             this.queue._delayedTimer.schedule(this.options.delay);
           }
-          return jobId;
         });
       }
     } else {
       promise = this.queue._evalScript('addJob', 3,
         toKey('id'), toKey('jobs'), toKey('waiting'),
-        this.id || '', this.toData());
+        this.id, this.toData());
     }
-
-    promise = promise.then((jobId) => {
-      this.id = jobId;
-      // If the jobId is not null, then store the job in the job map.
-      if (jobId && this.queue.settings.storeJobs) {
-        this.queue.jobs.set(jobId, this);
-      }
-      return this;
-    });
+    promise = promise.then(() => this);
 
     if (cb) helpers.asCallback(promise, cb);
     return promise;

--- a/lib/lua/addDelayedJob.lua
+++ b/lib/lua/addDelayedJob.lua
@@ -1,5 +1,5 @@
 --[[
-key 1 -> bq:name:id (job ID counter)
+key 1 -> bq:name:id (most recently created job ID -- only purpose is for checkHealth() newestJob)
 key 2 -> bq:name:jobs
 key 3 -> bq:name:delayed
 key 4 -> bq:name:earlierDelayed
@@ -9,10 +9,8 @@ arg 3 -> job delay timestamp
 ]]
 
 local jobId = ARGV[1]
-if jobId == "" then
-  jobId = "" .. redis.call("incr", KEYS[1])
-end
 if redis.call("hexists", KEYS[2], jobId) == 1 then return nil end
+redis.call("set", KEYS[1], jobId)
 redis.call("hset", KEYS[2], jobId, ARGV[2])
 redis.call("zadd", KEYS[3], tonumber(ARGV[3]), jobId)
 

--- a/lib/lua/addJob.lua
+++ b/lib/lua/addJob.lua
@@ -1,5 +1,5 @@
 --[[
-key 1 -> bq:name:id (job ID counter)
+key 1 -> bq:name:id (most recently created job ID -- only purpose is for checkHealth() newestJob)
 key 2 -> bq:name:jobs
 key 3 -> bq:name:waiting
 arg 1 -> job id
@@ -7,11 +7,7 @@ arg 2 -> job data
 ]]
 
 local jobId = ARGV[1]
-if jobId == "" then
-  jobId = "" .. redis.call("incr", KEYS[1])
-end
-if redis.call("hexists", KEYS[2], jobId) == 1 then return nil end
+if redis.call("hexists", KEYS[2], jobId) == 1 then return end
+redis.call("set", KEYS[1], jobId)
 redis.call("hset", KEYS[2], jobId, ARGV[2])
 redis.call("lpush", KEYS[3], jobId)
-
-return jobId

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -261,7 +261,7 @@ class Queue extends Emitter {
       succeeded: results[2],
       failed: results[3],
       delayed: results[4],
-      newestJob: results[5] ? parseInt(results[5], 10) : 0
+      newestJob: results[5],
     }));
 
     if (cb) helpers.asCallback(promise, cb);
@@ -725,6 +725,7 @@ class Queue extends Emitter {
       .then((results) => {
         const numRaised = results[0], nextOpportunity = results[1];
         if (numRaised) {
+          // not documented
           this.emit('raised jobs', numRaised);
         }
         this._delayedTimer.schedule(parseInt(nextOpportunity, 10));

--- a/test/queue-test.js
+++ b/test/queue-test.js
@@ -342,7 +342,7 @@ describe('Queue', (it) => {
         const jobs = spitter();
         queue.process((job) => jobs.pushSuspend(job));
 
-        await queue.createJob({}).save();
+        const job = await queue.createJob({}).save();
         const [, finishJob] = await jobs.shift();
 
         await t.throws(queue.close(10));
@@ -352,7 +352,7 @@ describe('Queue', (it) => {
 
         const errors = t.context.queueErrors, count = errors.length;
         t.context.queueErrors = errors.filter((err) => {
-          return err.message !== 'unable to update the status of succeeded job 1';
+          return err.message !== `unable to update the status of succeeded job ${job.id}`;
         });
         t.is(t.context.queueErrors.length, count - 1);
         t.context.handleErrors(t);
@@ -1163,7 +1163,7 @@ describe('Queue', (it) => {
       const [[failedJob, err]] = fail.args;
 
       t.truthy(failedJob);
-      t.is(job.id, '1');
+      t.is(job.id, failedJob.id);
       t.is(failedJob.data.foo, 'bar');
       t.is(err.message, `Job ${job.id} timed out (10 ms)`);
     });


### PR DESCRIPTION
These changes fix the problems reported in #189 and originally in #78 .  They do so by managing the job id in the Job object itself rather than in Redis.  Various simplifications emerge.  Note that with these changes, the only purpose of the `bq:name:id` key in Redis is to support the `newestJob` field returned by checkHealth().

A couple of tests fail because they rely on the incrementing numerical-properties of the old job-id creation or on the idea that user-provided job ids are special.  Whether user-provided ids are special  isn't clear to me.  So, I haven't tried to fix the tests yet.