### PR TITLE
RFC: feat(docker/dev): Add support for Docker-based dev testing and forensics

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+/.git
+/node_modules

--- a/Dockerfile-docker-scripts
+++ b/Dockerfile-docker-scripts
@@ -1,0 +1,14 @@
+FROM node:lts-alpine
+
+RUN apk add bash redis
+
+WORKDIR /bee-queue
+COPY package.json package-lock.json /bee-queue/
+RUN cd /bee-queue && npm --version && npm ci
+
+ENTRYPOINT ["/bee-queue/docker-scripts/entrypoint.sh"]
+
+COPY .eslintrc.json /bee-queue/
+COPY docker-scripts /bee-queue/docker-scripts/
+COPY test /bee-queue/test/
+COPY lib /bee-queue/lib/

--- a/README.md
+++ b/README.md
@@ -857,6 +857,20 @@ Some of these could be worthwhile additions; please comment if you're interested
 
 You'll need a local redis server to run the tests. Note that running the tests may delete some keys in the form of `bq:test-*-*:*`.
 
+Alternatively, if you have Docker available, you can run tests and do other dev forensics in a ephemeral container with its own Redis server, e.g.:
+```bash
+$ ./run-docker-script.sh
+
+$ ./run-docker-script.sh bash
+
+$ ./run-docker-script.sh npx ava --fail-fast --verbose
+
+$ ./run-docker-script.sh npm run ci
+
+$ ./run-docker-script.sh --help
+```
+
+
 [npm-image]: https://img.shields.io/npm/v/bee-queue.svg?style=flat
 [npm-url]: https://www.npmjs.com/package/bee-queue
 [travis-image]: https://img.shields.io/travis/bee-queue/bee-queue.svg?style=flat

--- a/docker-scripts/default-docker-script.sh
+++ b/docker-scripts/default-docker-script.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Default script to run in bee-queue-docker container
+
+# We don't do `npm run ci` because we may not have credentials to publish to coveralls
+
+set -eux
+
+# This ordering supports quick iteration on new testing
+npx ava
+npm run eslint
+npm run coverage

--- a/docker-scripts/entrypoint.sh
+++ b/docker-scripts/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Docker ENTRYPOINT target
+# - start a background Redis
+# - evalate user-provided arguments
+
+# See: https://raw.githubusercontent.com/antirez/redis/5.0/redis.conf
+# We don't use --daemonize because this is a dev configuration and we want to see warnings from Redis.
+# If someone knows how to prevent the "Transparent Huge Page" warning on Docker for Mac, please advise.
+/usr/bin/redis-server --tcp-backlog 128 --loglevel warning &
+
+eval "$@"

--- a/run-docker-script.sh
+++ b/run-docker-script.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Strict, and loud failure
+set -euo pipefail
+trap 'rc=$?;set +ex;if [[ $rc -ne 0 ]];then trap - ERR EXIT;echo 1>&2;echo "*** fail *** : code $rc : $DIR/$SCRIPT $ARGS" 1>&2;echo 1>&2;exit $rc;fi' ERR EXIT
+ARGS="$*"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$(basename "${BASH_SOURCE[0]}")"
+
+# A command or the name of a script to run in the container
+# Note: scripts must be in ./docker-scripts/ in order to get copied into the Docker image
+scriptName=${1:-docker-scripts/default-docker-script.sh}
+shift || true
+
+if [ "$scriptName" = -h -o "$scriptName" = --help ] ; then
+  cat <<EOF
+
+$SCRIPT -- Run a default test script or commands of your choice in a Docker
+container with the bee-queue library and a Redis server.
+
+Usage: $SCRIPT [command]
+
+The optional command argument is an executable or or a script to run in the
+container.  The default command is docker-scripts/default-docker-script.sh which
+runs tests, the linter, and test coverage.
+
+If you want to work interactively in the container, use bash, e.g.
+
+  $SCRIPT  bash
+
+Any script you want to use must be in the ./docker-scripts directory.  E.g. your
+script ./docker-scripts/my-testing.sh would be run via
+
+  $SCRIPT  docker-scripts/my-testing.sh
+
+Note: You can ignore the Transparent Huge Pages warning from Redis.
+EOF
+
+exit 0
+fi
+
+image=bee-queue-docker
+
+cd $DIR
+
+docker build --tag $image --file Dockerfile-docker-scripts .
+
+docker run --init -it --rm $image $scriptName "$@"

--- a/run-docker-script.sh
+++ b/run-docker-script.sh
@@ -18,22 +18,29 @@ if [ "$scriptName" = -h -o "$scriptName" = --help ] ; then
 $SCRIPT -- Run a default test script or commands of your choice in a Docker
 container with the bee-queue library and a Redis server.
 
-Usage: $SCRIPT [command]
+Usage: $SCRIPT [command ...args]
 
 The optional command argument is an executable or or a script to run in the
 container.  The default command is docker-scripts/default-docker-script.sh which
 runs tests, the linter, and test coverage.
 
+You can run Node JS tools and scripts, e.g.
+
+  $SCRIPT  npx ava --fail-fast --verbose
+
 If you want to work interactively in the container, use bash, e.g.
 
   $SCRIPT  bash
 
-Any script you want to use must be in the ./docker-scripts directory.  E.g. your
+Scripts must be in the ./docker-scripts directory.  E.g. your custom testing
 script ./docker-scripts/my-testing.sh would be run via
 
   $SCRIPT  docker-scripts/my-testing.sh
 
-Note: You can ignore the Transparent Huge Pages warning from Redis.
+Notes:
+- The very first time this script is used it takes a while for Docker to
+  populate its caches.
+- You can ignore the Transparent Huge Pages warning from the Redis server.
 EOF
 
 exit 0


### PR DESCRIPTION
Adds support for using Docker to test bee-queue.
```
$ ./run-docker-script.sh --help

run-docker-script.sh -- Run a default test script or commands of your choice in a Docker
container with the bee-queue library and a Redis server.

Usage: run-docker-script.sh [command ...args]

The optional command argument is an executable or or a script to run in the
container.  The default command is docker-scripts/default-docker-script.sh which
runs tests, the linter, and test coverage.

You can run Node JS tools and scripts, e.g.

  run-docker-script.sh  npx ava --fail-fast --verbose

If you want to work interactively in the container, use bash, e.g.

  run-docker-script.sh  bash

Scripts must be in the ./docker-scripts directory.  E.g. your custom testing
script ./docker-scripts/my-testing.sh would be run via

  run-docker-script.sh  docker-scripts/my-testing.sh

Notes:
- The very first time this script is used it takes a while for Docker to
  populate its caches.
- You can ignore the Transparent Huge Pages warning from the Redis server.
```