### PR TITLE
feat(test/RedisHost): Use optional env BEE_QUEUE_TEST_REDIS for Redis url during testing

### DIFF
--- a/test/delay-test.js
+++ b/test/delay-test.js
@@ -38,7 +38,8 @@ function reef(n = 1) {
 }
 
 describe('Delayed jobs', (it) => {
-  const gclient = redis.createClient();
+  const redisUrl = process.env.BEE_QUEUE_TEST_REDIS;
+  const gclient = redis.createClient(redisUrl);
 
   it.before(() => gclient);
 
@@ -55,6 +56,16 @@ describe('Delayed jobs', (it) => {
     });
 
     function makeQueue(...args) {
+      if (redisUrl) {
+        if (args.length === 0) {
+          args.push({});
+        }
+        if (!args[0].redis) {
+          // Note: we don't fuss with isClient(redis) because it's simpler to just
+          // add the host setting in the test code itself when redis is used
+          args[0].redis = redisUrl;
+        }
+      }
       const queue = new Queue(ctx.queueName, ...args);
       queue.on('error', (err) => ctx.queueErrors.push(err));
       ctx.queues.push(queue);

--- a/test/job-test.js
+++ b/test/job-test.js
@@ -7,13 +7,17 @@ import helpers from '../lib/helpers';
 import {promisify} from 'promise-callbacks';
 
 describe('Job', (it) => {
+  const redisUrl = process.env.BEE_QUEUE_TEST_REDIS;
+
   const data = {foo: 'bar'};
   const options = {test: 1};
 
   let uid = 0;
 
   it.beforeEach(async (t) => {
-    const queue = new Queue(`test-job-${uid++}`);
+    const queue = new Queue(`test-job-${uid++}`, {
+      redis: redisUrl,
+    });
 
     function makeJob() {
       const job = queue.createJob(data);


### PR DESCRIPTION
This allows use of a non-localhost Redis server.  It is necessary for the following PR which uses a non-local Redis host in a docker-compose container environment.

Regarding Docker: Not sure how to use PR base from my fork: see https://github.com/hughsw/bee-queue/pull/1  which uses docker-compose to run tests in a Docker  environment.