### PR TITLE
Fix dropped jobs issue

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -50,34 +50,48 @@ class Job extends Emitter {
     const toKey = this.queue.toKey.bind(this.queue);
 
     let promise;
+    if (this.id) {
+      promise = Promise.resolve();
+    } else {
+      // serialize creation of value for this.id through Redis
+      promise = this.queue._commandable().then((client) => {
+        const incrPromise = helpers.deferred();
+        client.incr(toKey('id'), incrPromise.defer());
+        return incrPromise;
+      })
+        .then((value) => {
+          this.id = value + '';
+        });
+    }
+
+    // We add to the stored-jobs set before addJob (or addDelayedJob) so that
+    // this job is already in the queue's map for the rare case of the job
+    // getting popped off 'waiting', completing, and making callbacks (which use
+    // the map) all before the _evalScript promise has resolved.
+    if (this.queue.settings.storeJobs) {
+      promise = promise.then(() => this.queue.jobs.set(this.id, this));
+    }
+
     if (this.options.delay) {
-      promise = this.queue._evalScript('addDelayedJob', 4,
-        toKey('id'), toKey('jobs'), toKey('delayed'), toKey('earlierDelayed'),
-        this.id || '', this.toData(), this.options.delay);
+      promise = promise.then(() => this.queue._evalScript('addDelayedJob', 3,
+        toKey('jobs'), toKey('delayed'), toKey('earlierDelayed'),
+        this.id, this.toData(), this.options.delay));
 
       if (this.queue.settings.activateDelayedJobs) {
         promise = promise.then((jobId) => {
-          // Only reschedule if the job was actually created.
+          // Only reschedule if a new job was actually created.
           if (jobId) {
             this.queue._delayedTimer.schedule(this.options.delay);
           }
-          return jobId;
         });
       }
     } else {
-      promise = this.queue._evalScript('addJob', 3,
-        toKey('id'), toKey('jobs'), toKey('waiting'),
-        this.id || '', this.toData());
+      promise = promise.then(() => this.queue._evalScript('addJob', 2,
+        toKey('jobs'), toKey('waiting'),
+        this.id, this.toData()));
     }
 
-    promise = promise.then((jobId) => {
-      this.id = jobId;
-      // If the jobId is not null, then store the job in the job map.
-      if (jobId && this.queue.settings.storeJobs) {
-        this.queue.jobs.set(jobId, this);
-      }
-      return this;
-    });
+    promise = promise.then(() => this);
 
     if (cb) helpers.asCallback(promise, cb);
     return promise;

--- a/lib/lua/addDelayedJob.lua
+++ b/lib/lua/addDelayedJob.lua
@@ -1,28 +1,24 @@
 --[[
-key 1 -> bq:name:id (job ID counter)
-key 2 -> bq:name:jobs
-key 3 -> bq:name:delayed
-key 4 -> bq:name:earlierDelayed
+key 1 -> bq:name:jobs
+key 2 -> bq:name:delayed
+key 3 -> bq:name:earlierDelayed
 arg 1 -> job id
 arg 2 -> job data
 arg 3 -> job delay timestamp
 ]]
 
 local jobId = ARGV[1]
-if jobId == "" then
-  jobId = "" .. redis.call("incr", KEYS[1])
-end
-if redis.call("hexists", KEYS[2], jobId) == 1 then return nil end
-redis.call("hset", KEYS[2], jobId, ARGV[2])
-redis.call("zadd", KEYS[3], tonumber(ARGV[3]), jobId)
+if redis.call("hexists", KEYS[1], jobId) == 1 then return nil end
+redis.call("hset", KEYS[1], jobId, ARGV[2])
+redis.call("zadd", KEYS[2], tonumber(ARGV[3]), jobId)
 
 -- if this job is the new head, alert the workers that they need to update their timers
 -- if we try to do something tricky like checking the delta between this job and the next job, we
 -- can enter a pathological case where jobs incrementally creep sooner, and each one never updates
 -- the timers
-local head = redis.call("zrange", KEYS[3], 0, 0)
+local head = redis.call("zrange", KEYS[2], 0, 0)
 if head[1] == jobId then
-  redis.call("publish", KEYS[4], ARGV[3])
+  redis.call("publish", KEYS[3], ARGV[3])
 end
 
 return jobId

--- a/lib/lua/addJob.lua
+++ b/lib/lua/addJob.lua
@@ -1,17 +1,11 @@
 --[[
-key 1 -> bq:name:id (job ID counter)
-key 2 -> bq:name:jobs
-key 3 -> bq:name:waiting
+key 1 -> bq:name:jobs
+key 2 -> bq:name:waiting
 arg 1 -> job id
 arg 2 -> job data
 ]]
 
 local jobId = ARGV[1]
-if jobId == "" then
-  jobId = "" .. redis.call("incr", KEYS[1])
-end
-if redis.call("hexists", KEYS[2], jobId) == 1 then return nil end
-redis.call("hset", KEYS[2], jobId, ARGV[2])
-redis.call("lpush", KEYS[3], jobId)
-
-return jobId
+if redis.call("hexists", KEYS[1], jobId) == 1 then return end
+redis.call("hset", KEYS[1], jobId, ARGV[2])
+redis.call("lpush", KEYS[2], jobId)

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -725,6 +725,7 @@ class Queue extends Emitter {
       .then((results) => {
         const numRaised = results[0], nextOpportunity = results[1];
         if (numRaised) {
+          // not documented
           this.emit('raised jobs', numRaised);
         }
         this._delayedTimer.schedule(parseInt(nextOpportunity, 10));


### PR DESCRIPTION
Changes to fix problem reported in #189 and #78 

This fix adopts an approach mentioned in #78 of making a separate Redis call to updated the id counter.  Some simplifications emerge.

The example code in #196 shows no lost jobs when run against this branch.