### PR TITLE
fix(queue): remove error event listener on close

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -75,6 +75,8 @@ class Queue extends Emitter {
       return redis
         .createClient(this.settings.redis, createNew)
         .then((client) => {
+          // This event gets cleaned up and removed in Queue#close for the
+          // primary client if quitCommandClient is disabled.
           client.on('error', this._emitError);
           return (this[clientName] = client);
         });
@@ -222,8 +224,12 @@ class Queue extends Emitter {
       this._isClosed = true;
 
       const clients = [];
-      if (this.settings.quitCommandClient && this.client) {
-        clients.push(this.client);
+      if (this.client) {
+        if (this.settings.quitCommandClient) {
+          clients.push(this.client);
+        } else {
+          this.client.removeListener('error', this._emitError);
+        }
       }
       if (this.eclient) {
         clients.push(this.eclient);


### PR DESCRIPTION
The error event listener is useful for catching errors from redis clients that aren't managed by the consumer of the library, but might cause problems for re-used connections.

Fixes #102 (per the extended discussion) cc @dylanjha.