### PR TITLE
fix: prevent event delivery race condition

### DIFF
--- a/benchmark/bq/harness.js
+++ b/benchmark/bq/harness.js
@@ -16,14 +16,13 @@ const queue = new Queue(
 
 // A promise-based barrier.
 function reef(n = 1) {
-  const done = helpers.deferred(),
-    end = done.defer();
+  const done = helpers.defer();
   return {
-    done,
+    done: done.promise,
     next() {
       --n;
       if (n < 0) return false;
-      if (n === 0) end();
+      if (n === 0) done.resolve();
       return true;
     },
   };

--- a/benchmark/bull/harness.js
+++ b/benchmark/bull/harness.js
@@ -4,14 +4,13 @@ const queue = new Queue('test');
 
 // A promise-based barrier.
 function reef(n = 1) {
-  const done = helpers.deferred(),
-    end = done.defer();
+  const done = helpers.defer();
   return {
-    done,
+    done: done.promise,
     next() {
       --n;
       if (n < 0) return false;
-      if (n === 0) end();
+      if (n === 0) done.resolve();
       return true;
     },
   };

--- a/benchmark/kue/harness.js
+++ b/benchmark/kue/harness.js
@@ -4,14 +4,13 @@ const queue = kue.createQueue();
 
 // A promise-based barrier.
 function reef(n = 1) {
-  const done = helpers.deferred(),
-    end = done.defer();
+  const done = helpers.defer();
   return {
-    done,
+    done: done.promise,
     next() {
       --n;
       if (n < 0) return false;
-      if (n === 0) end();
+      if (n === 0) done.resolve();
       return true;
     },
   };
@@ -31,9 +30,7 @@ module.exports = (options) => {
   }
   return done.then(() => {
     const elapsed = Date.now() - startTime;
-    const promise = helpers.deferred();
-    queue.shutdown(promise.defer());
-    return promise.then(() => elapsed);
+    return helpers.callAsync((cb) => queue.shutdown(cb)).then(() => elapsed);
   });
 };
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -28,6 +28,20 @@ function immediateThen(promiseOrValue, fn) {
     : fn(promiseOrValue);
 }
 
+function emitHandleErrors(emitter, args) {
+  try {
+    emitter.emit.apply(emitter, args);
+  } catch (err) {
+    emitter.emit('error:user', err) ||
+      // It's not easy to capture uncaught exceptions in ava.
+      /* istanbul ignore next: just use the error:user event */
+      process.nextTick(() => {
+        /* istanbul ignore next */
+        throw err;
+      });
+  }
+}
+
 const promiseUtils = require('promise-callbacks');
 
 module.exports = {
@@ -36,6 +50,7 @@ module.exports = {
   defer: promiseUtils.defer,
   deferred: promiseUtils.deferred,
   delay: promiseUtils.delay,
+  emitHandleErrors,
   finallyRejectsWithInitial,
   promisify: promiseUtils.promisify,
   has,

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -22,6 +22,12 @@ function finallyRejectsWithInitial(promise, fn) {
   );
 }
 
+function immediateThen(promiseOrValue, fn) {
+  return promiseOrValue && typeof promiseOrValue.then === 'function'
+    ? promiseOrValue.then(fn)
+    : fn(promiseOrValue);
+}
+
 const promiseUtils = require('promise-callbacks');
 
 module.exports = {
@@ -30,7 +36,9 @@ module.exports = {
   deferred: promiseUtils.deferred,
   delay: promiseUtils.delay,
   finallyRejectsWithInitial,
+  promisify: promiseUtils.promisify,
   has,
+  immediateThen,
   waitOn: promiseUtils.waitOn,
   withTimeout: promiseUtils.withTimeout,
   wrapAsync: promiseUtils.wrapAsync,

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -33,6 +33,7 @@ const promiseUtils = require('promise-callbacks');
 module.exports = {
   asCallback: promiseUtils.asCallback,
   callAsync: promiseUtils.callAsync,
+  defer: promiseUtils.defer,
   deferred: promiseUtils.deferred,
   delay: promiseUtils.delay,
   finallyRejectsWithInitial,

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -48,7 +48,6 @@ module.exports = {
   asCallback: promiseUtils.asCallback,
   callAsync: promiseUtils.callAsync,
   defer: promiseUtils.defer,
-  deferred: promiseUtils.deferred,
   delay: promiseUtils.delay,
   emitHandleErrors,
   finallyRejectsWithInitial,

--- a/lib/job.js
+++ b/lib/job.js
@@ -17,6 +17,7 @@ class Job extends Emitter {
     this.options.timestamp = this.options.timestamp || Date.now();
     this.options.stacktraces = this.options.stacktraces || [];
     this.status = 'created';
+    this._localID = null;
   }
 
   static fromId(queue, jobId, cb) {
@@ -49,21 +50,48 @@ class Job extends Emitter {
     });
   }
 
+  _assignLocalJobID(clientUUID) {
+    this.options.localID = `${clientUUID}:${this._localID}`;
+  }
+
+  _generateLocalJobID() {
+    if (!this.queue._generateLocalJobID) {
+      return Promise.resolve(null);
+    }
+
+    if (this._localID === null) {
+      this._localID = this.queue._localJobIDCounter++;
+      this.queue._jobsByLocalID.set(String(this._localID), this);
+    }
+
+    const clientUUID = this.queue._resolvedClientUUID;
+    if (clientUUID) {
+      this._assignLocalJobID(clientUUID);
+      return clientUUID;
+    }
+
+    return this.queue._clientUUID.then(this._assignLocalJobID.bind(this));
+  }
+
   save(cb) {
     const toKey = this.queue.toKey.bind(this.queue);
 
+    const localJobID = this._generateLocalJobID();
+
     let promise;
     if (this.options.delay) {
-      promise = this.queue._evalScript(
-        'addDelayedJob',
-        4,
-        toKey('id'),
-        toKey('jobs'),
-        toKey('delayed'),
-        toKey('earlierDelayed'),
-        this.id || '',
-        this.toData(),
-        this.options.delay
+      promise = helpers.immediateThen(localJobID, () =>
+        this.queue._evalScript(
+          'addDelayedJob',
+          4,
+          toKey('id'),
+          toKey('jobs'),
+          toKey('delayed'),
+          toKey('earlierDelayed'),
+          this.id || '',
+          this.toData(),
+          this.options.delay
+        )
       );
 
       if (this.queue.settings.activateDelayedJobs) {
@@ -76,14 +104,16 @@ class Job extends Emitter {
         });
       }
     } else {
-      promise = this.queue._evalScript(
-        'addJob',
-        3,
-        toKey('id'),
-        toKey('jobs'),
-        toKey('waiting'),
-        this.id || '',
-        this.toData()
+      promise = helpers.immediateThen(localJobID, () =>
+        this.queue._evalScript(
+          'addJob',
+          3,
+          toKey('id'),
+          toKey('jobs'),
+          toKey('waiting'),
+          this.id || '',
+          this.toData()
+        )
       );
     }
 

--- a/lib/job.js
+++ b/lib/job.js
@@ -55,8 +55,8 @@ class Job extends Emitter {
   }
 
   _generateLocalJobID() {
-    if (!this.queue._generateLocalJobID) {
-      return Promise.resolve(null);
+    if (this.id || !this.queue._generateLocalJobID) {
+      return null;
     }
 
     if (this._localID === null) {

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -156,6 +156,10 @@ class Queue extends Emitter {
       });
   }
 
+  _emitHandleErrors(args) {
+    helpers.emitHandleErrors(this, args);
+  }
+
   _onJobMessage(job, message) {
     if (!job) return;
 
@@ -173,7 +177,7 @@ class Queue extends Emitter {
         break;
     }
 
-    job.emit(event, message.data);
+    helpers.emitHandleErrors(job, [event, message.data]);
 
     if (event === 'succeeded' || event === 'failed') {
       this.jobs.delete(message.id);
@@ -211,7 +215,7 @@ class Queue extends Emitter {
       message.data = new Error(message.data);
     }
 
-    this.emit(`job ${message.event}`, message.id, message.data);
+    this._emitHandleErrors([`job ${message.event}`, message.id, message.data]);
 
     this._onJobMessage(this._identifyJobFromMessage(message), message);
   }
@@ -756,7 +760,7 @@ class Queue extends Emitter {
             if (results) {
               const status = results[0],
                 result = results[1];
-              this.emit(status, job, result);
+              this._emitHandleErrors([status, job, result]);
             }
           }, this._emitErrorAfterTick);
         }),
@@ -782,7 +786,7 @@ class Queue extends Emitter {
     )
       .then((stalled) => {
         for (const jobId of stalled) {
-          this.emit('stalled', jobId);
+          this._emitHandleErrors(['stalled', jobId]);
         }
         return stalled.length;
       })
@@ -858,7 +862,7 @@ class Queue extends Emitter {
         const numRaised = results[0],
           nextOpportunity = results[1];
         if (numRaised) {
-          this.emit('raised jobs', numRaised);
+          this._emitHandleErrors(['raised jobs', numRaised]);
         }
         this._delayedTimer.schedule(parseInt(nextOpportunity, 10));
       },

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -323,23 +323,23 @@ class Queue extends Emitter {
   }
 
   destroy(cb) {
-    const promise = this._commandable().then((client) => {
-      const deleted = helpers.deferred();
-      const args = [
-        'id',
-        'jobs',
-        'stallBlock',
-        'stalling',
-        'waiting',
-        'active',
-        'succeeded',
-        'failed',
-        'delayed',
-      ].map((key) => this.toKey(key));
-      args.push(deleted.defer());
-      client.del.apply(client, args);
-      return deleted;
-    });
+    const promise = this._commandable().then((client) =>
+      helpers.callAsync((done) => {
+        const args = [
+          'id',
+          'jobs',
+          'stallBlock',
+          'stalling',
+          'waiting',
+          'active',
+          'succeeded',
+          'failed',
+          'delayed',
+        ].map((key) => this.toKey(key));
+        args.push(done);
+        client.del.apply(client, args);
+      })
+    );
 
     if (cb) helpers.asCallback(promise, cb);
     return promise;
@@ -407,12 +407,11 @@ class Queue extends Emitter {
     // We need to re-ensure the queue is commandable, as we might be shutting
     // down during this operation.
     return this._commandable()
-      .then((client) => {
-        const got = helpers.deferred();
-        const commandArgs = [this.toKey('jobs')].concat(ids, got.defer());
-        client.hmget.apply(client, commandArgs);
-        return got;
-      })
+      .then((client) =>
+        helpers.callAsync((done) =>
+          client.hmget.apply(client, [this.toKey('jobs')].concat(ids, done))
+        )
+      )
       .then((dataArray) => {
         const count = ids.length;
         // Some jobs returned by the scan may have already been removed, so
@@ -458,28 +457,26 @@ class Queue extends Emitter {
       page
     );
     const promise = this._commandable()
-      .then((client) => {
-        const idsPromise = helpers.deferred(),
-          next = idsPromise.defer();
-        const key = this.toKey(type);
-        switch (type) {
-          case 'failed':
-          case 'succeeded':
-            this._scanForJobs(key, '0', page.size, new Set(), next);
-            break;
-          case 'waiting':
-          case 'active':
-            client.lrange(key, page.start, page.end, next);
-            break;
-          case 'delayed':
-            client.zrange(key, page.start, page.end, next);
-            break;
-          default:
-            throw new Error('Improper queue type');
-        }
-
-        return idsPromise;
-      })
+      .then((client) =>
+        helpers.callAsync((next) => {
+          const key = this.toKey(type);
+          switch (type) {
+            case 'failed':
+            case 'succeeded':
+              this._scanForJobs(key, '0', page.size, new Set(), next);
+              break;
+            case 'waiting':
+            case 'active':
+              client.lrange(key, page.start, page.end, next);
+              break;
+            case 'delayed':
+              client.zrange(key, page.start, page.end, next);
+              break;
+            default:
+              throw new Error('Improper queue type');
+          }
+        })
+      )
       .then((ids) => {
         const jobs = [],
           idsToFetch = [];
@@ -897,16 +894,16 @@ class Queue extends Emitter {
       args[i] = arguments[i];
     }
 
-    return this._commandable().then((client) => {
-      // Get the sha for the script after we're ready to avoid a race condition
-      // with the lua script loader.
-      args[0] = lua.shas[name];
+    return this._commandable().then((client) =>
+      helpers.callAsync((done) => {
+        // Get the sha for the script after we're ready to avoid a race
+        // condition with the lua script loader.
+        args[0] = lua.shas[name];
 
-      const promise = helpers.deferred();
-      args.push(promise.defer());
-      client.evalsha.apply(client, args);
-      return promise;
-    });
+        args.push(done);
+        client.evalsha.apply(client, args);
+      })
+    );
   }
 }
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -10,6 +10,11 @@ const helpers = require('./helpers');
 const backoff = require('./backoff');
 const EagerTimer = require('./eager-timer');
 const finally_ = require('p-finally');
+const crypto = require('crypto');
+
+const CLIENT_ID_BYTES = 16;
+
+const randomBytes = helpers.promisify(crypto.randomBytes);
 
 class Queue extends Emitter {
   constructor(name, settings) {
@@ -49,6 +54,34 @@ class Queue extends Emitter {
         this.settings[prop] = Number.isSafeInteger(setting) ? setting : def;
       }
     }
+
+    this._generateLocalJobID = !!(
+      this.settings.clientUUID ||
+      (this.settings.storeJobs && this.settings.getEvents)
+    );
+    this._resolvedClientUUID = null;
+    this._clientUUID = null;
+    if (settings.clientUUID || this._generateLocalJobID) {
+      const clientUUID = settings.clientUUID
+        ? Promise.resolve(settings.clientUUID)
+        : randomBytes(CLIENT_ID_BYTES).then((buffer) =>
+            buffer
+              .toString('base64')
+              .replace(/=+$/, '')
+              .replace(/=/g, '_')
+              .replace(/\//g, '-')
+          );
+      clientUUID.catch(() => {
+        this._jobsByLocalID = null;
+        this._generateLocalJobID = false;
+      });
+      this._clientUUID = finally_(
+        clientUUID,
+        () => (this._clientUUID = null)
+      ).then((value) => (this._resolvedClientUUID = value));
+    }
+    this._localJobIDCounter = 0;
+    this._jobsByLocalID = this._generateLocalJobID ? new Map() : null;
 
     /* istanbul ignore if */
     if (this.settings.redis.socket) {
@@ -109,6 +142,7 @@ class Queue extends Emitter {
       makeClient('client', false),
       this.settings.isWorker ? makeClient('bclient', true) : null,
       eventsPromise,
+      this._clientUUID,
     ])
       .then(() => {
         if (this.settings.ensureScripts) {
@@ -122,7 +156,49 @@ class Queue extends Emitter {
       });
   }
 
-  _onMessage(channel, message) {
+  _onJobMessage(job, message) {
+    if (!job) return;
+
+    const event = message.event;
+    switch (event) {
+      case 'progress':
+        job.progress = message.data;
+        break;
+      case 'retrying':
+        --job.options.retries;
+      // fallthrough
+      case 'succeeded':
+      case 'failed':
+        job.status = event;
+        break;
+    }
+
+    job.emit(event, message.data);
+
+    if (event === 'succeeded' || event === 'failed') {
+      this.jobs.delete(message.id);
+    }
+  }
+
+  _identifyJobFromMessage(message) {
+    const job = this.jobs.get(message.id);
+    if (job) return job;
+
+    const localJobID = message.localID;
+    // If the clientUUID hasn't resolved yet, then there's no way we've already
+    // published a job. We can just ignore any unattributed messages at this
+    // point if that's the case.
+    if (!this._jobsByLocalID || !this._resolvedClientUUID || !localJobID) {
+      return null;
+    }
+
+    const prefix = `${this._resolvedClientUUID}:`;
+    return localJobID.startsWith(prefix)
+      ? this._jobsByLocalID.get(localJobID.slice(prefix.length))
+      : null;
+  }
+
+  _onMessageInner(channel, message) {
     if (channel === this.toKey('earlierDelayed')) {
       // We should only receive these messages if activateDelayedJobs is
       // enabled.
@@ -135,21 +211,16 @@ class Queue extends Emitter {
       message.data = new Error(message.data);
     }
 
-    this.emit('job ' + message.event, message.id, message.data);
+    this.emit(`job ${message.event}`, message.id, message.data);
 
-    const job = this.jobs.get(message.id);
-    if (job) {
-      if (message.event === 'progress') {
-        job.progress = message.data;
-      } else if (message.event === 'retrying') {
-        job.options.retries -= 1;
-      }
+    this._onJobMessage(this._identifyJobFromMessage(message), message);
+  }
 
-      job.emit(message.event, message.data);
-
-      if (message.event === 'succeeded' || message.event === 'failed') {
-        this.jobs.delete(message.id);
-      }
+  _onMessage() {
+    try {
+      this._onMessageInner.apply(this, arguments);
+    } catch (err) {
+      this._emitError(err);
     }
   }
 
@@ -558,6 +629,7 @@ class Queue extends Emitter {
 
     const jobEvent = {
       id: job.id,
+      localID: job.options.localID || undefined,
       event: status,
       data: err ? err.message : data,
     };

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -779,12 +779,14 @@ class Queue extends Emitter {
       this.toKey('waiting'),
       this.toKey('active'),
       this.settings.stallInterval
-    ).then((stalled) => {
-      for (const jobId of stalled) {
-        this.emit('stalled', jobId);
-      }
-      return stalled.length;
-    });
+    )
+      .then((stalled) => {
+        for (const jobId of stalled) {
+          this.emit('stalled', jobId);
+        }
+        return stalled.length;
+      })
+      .catch(this._emitErrorAfterTick);
   }
 
   _safeCheckStalledJobs(interval, cb) {

--- a/test/delay-test.js
+++ b/test/delay-test.js
@@ -4,34 +4,28 @@ import Queue from '../lib/queue';
 import helpers from '../lib/helpers';
 import sinon from 'sinon';
 
+import {deferred} from 'promise-callbacks';
+
 import redis from '../lib/redis';
 
 import {EventEmitter as Emitter} from 'events';
 
-function delKeys(client, pattern) {
-  const promise = helpers.deferred(),
-    done = promise.defer();
-  client.keys(pattern, (err, keys) => {
-    if (err) return done(err);
-    if (keys.length) {
-      client.del(keys, done);
-    } else {
-      done();
-    }
-  });
-  return promise;
+async function delKeys(client, pattern) {
+  const keys = await helpers.callAsync((done) => client.keys(pattern, done));
+  if (keys.length) {
+    return helpers.callAsync((done) => client.del(keys, done));
+  }
 }
 
 // A promise-based barrier.
 function reef(n = 1) {
-  const done = helpers.deferred(),
-    end = done.defer();
+  const done = helpers.defer();
   return {
-    done,
+    done: done.promise,
     next() {
       --n;
       if (n < 0) return false;
-      if (n === 0) end();
+      if (n === 0) done.resolve();
       return true;
     },
   };
@@ -187,7 +181,7 @@ describe('Delayed jobs', (it) => {
       nearTermWindow: 100,
     });
 
-    let scheduled = helpers.deferred(),
+    let scheduled = deferred(),
       onSchedule = scheduled.defer();
 
     const mockTimer = new Emitter();
@@ -220,7 +214,7 @@ describe('Delayed jobs', (it) => {
     t.is(mockTimer.schedule.secondCall.args[0], start + 150);
     await scheduled;
 
-    scheduled = helpers.deferred();
+    scheduled = deferred();
     onSchedule = scheduled.defer();
     mockTimer.emit('trigger');
     t.is(await scheduled, start + 150);

--- a/test/job-test.js
+++ b/test/job-test.js
@@ -163,9 +163,7 @@ describe('Job', (it) => {
       const {hget} = promisify.methods(queue.client, ['hget']);
 
       const job = await makeJob();
-      const removed = helpers.deferred();
-      job.remove(removed.defer());
-      await removed;
+      await helpers.callAsync((done) => job.remove(done));
 
       t.is(await hget(queue.toKey('jobs'), job.id), null);
     });
@@ -198,9 +196,9 @@ describe('Job', (it) => {
       const {queue, makeJob} = t.context;
 
       const job = await makeJob();
-      const promise = helpers.deferred();
-      Job.fromId(queue, job.id, promise.defer());
-      const storedJob = await promise;
+      const storedJob = await helpers.callAsync((done) =>
+        Job.fromId(queue, job.id, done)
+      );
       t.truthy(storedJob);
       t.true(helpers.has(storedJob, 'id'));
       t.deepEqual(storedJob.data, data);

--- a/test/queue-test.js
+++ b/test/queue-test.js
@@ -565,19 +565,7 @@ describe('Queue', (it) => {
       // Not called at all yet because queue.process uses setImmediate.
       t.is(jobSpy.callCount, 0);
 
-      // Override _waitForJob.
-      const waitJob = queue._waitForJob,
-        wait = helpers.deferred();
-      let waitDone = wait.defer();
-      queue._waitForJob = function (...args) {
-        if (waitDone) {
-          waitDone();
-          waitDone = null;
-        }
-        return waitJob.apply(this, args);
-      };
-
-      await wait;
+      await waitMethod(queue, '_waitForJob');
 
       const errored = helpers.waitOn(queue, 'error');
 

--- a/test/queue-test.js
+++ b/test/queue-test.js
@@ -1389,7 +1389,7 @@ describe('Queue', (it) => {
       queue.process(async (job) => {
         t.is(job.data.foo, 'bar');
         if (job.options.retries) {
-          return helpers.defer(20);
+          return helpers.delay(20);
         }
         t.is(failCount, retries);
         finish();


### PR DESCRIPTION
This solution introduces a new client-specific identifier that can be used independent of the normal identifier. This approach permits the continued use of the global incrementing queue `id` so that we don't break existing requirements around the use of that `id` for reporting and metrics.

Fixes #189, adds tests to fix #22.