### PR TITLE
docs(examples): Add Express example using Docker containers

### DIFF
--- a/examples/docker/02-express-1/Dockerfile
+++ b/examples/docker/02-express-1/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:lts-alpine
+
+# Minimalist image with bee-queue package and local JS files
+
+WORKDIR /bee-queue-express-1
+
+RUN npm init --name=bee-queue-express-1 --yes
+RUN npm install bee-queue morgan express --no-package-lock --only prod
+
+COPY *.js ./

--- a/examples/docker/02-express-1/Readme.md
+++ b/examples/docker/02-express-1/Readme.md
@@ -1,0 +1,26 @@
+# Simple Express example using Bee-Queue in Docker
+
+This example uses a Bee-Queue worker to catenate two strings provided via a web-service API.
+
+The code is taken directly from the [terminal-based Express example](file:../../express/README.md).
+
+## Run it
+
+The `./go.sh` script starts the example web server and bee-queue worker.
+
+Once it's running, browse here:
+* http://localhost:3000/run/2/3
+* http://localhost:3000/run/Hello%20/World
+
+Logged output shows the processing steps, with latency measures that include the Bee-Queue round trip.
+Ctrl-C shuts it all down.
+
+
+## Manifest
+* web.js -- **Express server that gets an API request, submits a job, and returns job result**
+* worker.js -- **Worker process that catenates the two strings in the job**
+
+* Dockerfile -- Script used by Docker to build our image
+* Readme.md -- Overview desciption
+* docker-compose.yml -- Declarations for naming and running the three containers
+* go.sh -- Script that uses docker-compose to build image and then run the containers

--- a/examples/docker/02-express-1/Readme.md
+++ b/examples/docker/02-express-1/Readme.md
@@ -9,18 +9,19 @@ The code is taken directly from the [terminal-based Express example](file:../../
 The `./go.sh` script starts the example web server and bee-queue worker.
 
 Once it's running, browse here:
-* http://localhost:3000/run/2/3
-* http://localhost:3000/run/Hello%20/World
+
+- http://localhost:3000/run/2/3
+- http://localhost:3000/run/Hello%20/World
 
 Logged output shows the processing steps, with latency measures that include the Bee-Queue round trip.
 Ctrl-C shuts it all down.
 
-
 ## Manifest
-* web.js -- **Express server that gets an API request, submits a job, and returns job result**
-* worker.js -- **Worker process that catenates the two strings in the job**
 
-* Dockerfile -- Script used by Docker to build our image
-* Readme.md -- Overview desciption
-* docker-compose.yml -- Declarations for naming and running the three containers
-* go.sh -- Script that uses docker-compose to build image and then run the containers
+- web.js -- **Express server that gets an API request, submits a job, and returns job result**
+- worker.js -- **Worker process that catenates the two strings in the job**
+
+- Dockerfile -- Script used by Docker to build our image
+- Readme.md -- Overview desciption
+- docker-compose.yml -- Declarations for naming and running the three containers
+- go.sh -- Script that uses docker-compose to build image and then run the containers

--- a/examples/docker/02-express-1/docker-compose.yml
+++ b/examples/docker/02-express-1/docker-compose.yml
@@ -1,7 +1,6 @@
 version: '3.7'
 
 services:
-
   # Run web.js in a container created from our image
   web:
     build: .
@@ -13,7 +12,6 @@ services:
   worker:
     build: .
     command: node worker.js
-
 
   # Run Redis in a container created from the redis:alpine image from Docker Hub
   redis:

--- a/examples/docker/02-express-1/docker-compose.yml
+++ b/examples/docker/02-express-1/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.7'
+
+services:
+
+  # Run web.js in a container created from our image
+  web:
+    build: .
+    command: node web.js
+    ports:
+      - '3000:3000'
+
+  # Run worker.js in a container created from our image
+  worker:
+    build: .
+    command: node worker.js
+
+
+  # Run Redis in a container created from the redis:alpine image from Docker Hub
+  redis:
+    image: redis:alpine
+    command: redis-server --tcp-backlog 128 --logfile /dev/null

--- a/examples/docker/02-express-1/go.sh
+++ b/examples/docker/02-express-1/go.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Build and run bee-queue Docker containers to do Hello World
+
+# Strict and loud fail
+set -euo pipefail
+trap 'rc=$?;set +ex;if [[ $rc -ne 0 ]];then trap - ERR EXIT;echo 1>&2;echo "*** fail *** : code $rc : $DIR/$SCRIPT $ARGS" 1>&2;echo 1>&2;exit $rc;fi' ERR EXIT
+ARGS="$*"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$(basename "${BASH_SOURCE[0]}")"
+
+docker-compose down > /dev/null 2>&1 || true
+
+set -x
+docker-compose build --quiet
+docker-compose up --abort-on-container-exit --timeout 3 --renew-anon-volumes
+set +x

--- a/examples/docker/02-express-1/web.js
+++ b/examples/docker/02-express-1/web.js
@@ -1,0 +1,33 @@
+const logger = require('morgan');
+const express = require('express');
+const app = express();
+app.use(logger('dev'));
+
+const Queue = require('bee-queue');
+const queue = new Queue('express-example', {redis: {host: 'redis'}});
+
+app.get('/run/:x/:y', function (req, res) {
+  const job = queue.createJob({
+    x: req.params.x,
+    y: req.params.y,
+  });
+
+  job.on('succeeded', function (result) {
+    console.log('completed job ' + job.id);
+    res.send('output: ' + result);
+  });
+
+  job.save(function (err) {
+    if (err) {
+      console.log('job failed to save');
+      return res.send('job failed to save');
+    }
+    console.log('saved job ' + job.id);
+  });
+});
+
+const server = app.listen(3000, function () {
+  const host = server.address().address;
+  const port = server.address().port;
+  console.log('Example app listening at http://%s:%s', host, port, '  Browse here:  http://localhost:3000/run/2/3');
+});

--- a/examples/docker/02-express-1/worker.js
+++ b/examples/docker/02-express-1/worker.js
@@ -1,0 +1,13 @@
+const Queue = require('bee-queue');
+const queue = new Queue('express-example', {redis: {host: 'redis'}});
+
+queue.on('ready', function () {
+  queue.process(function (job, done) {
+    console.log('processing job ' + job.id);
+    setTimeout(function () {
+      done(null, job.data.x + job.data.y);
+    }, 10);
+  });
+
+  console.log('processing jobs...');
+});


### PR DESCRIPTION
Dockerized version of the Express example.

Me wonders if the intent was to add the two parameters of the API call as numbers, rather than catenate them...?