### PR TITLE
Update Redis configuration type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@
 /// <reference types="redis" />
 
 import {EventEmitter} from 'events';
-import {ClientOpts} from 'redis';
+import {ClientOpts, RedisClient} from 'redis';
 
 declare class BeeQueue<T = any> extends EventEmitter {
   name: string;
@@ -87,7 +87,7 @@ declare namespace BeeQueue {
     stallInterval?: number;
     nearTermWindow?: number;
     delayedDebounce?: number;
-    redis?: ClientOpts;
+    redis?: ClientOpts | RedisClient;
     isWorker?: boolean;
     getEvents?: boolean;
     sendEvents?: boolean;


### PR DESCRIPTION
The Redis QueueSettings prop can accept a node_redis client object, but this wasn't reflected in the typings. If a Typescript user tried to set a RedisClient, Typescript would not compile without using `@ts-ignore`.

This PR fixes that by adding the `RedisClient` type to the `redis` prop as a union type.