### PR TITLE
Clear jobs if we try to fetch them and they aren't there

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ The `settings` fields are:
 - `removeOnFailure`: boolean. Enable to have this worker automatically remove its failed jobs from Redis, so as to keep memory usage down. This will not remove jobs that are set to retry unless they fail all their retries.
 - `quitCommandClient`: boolean. Whether to `QUIT` the redis command client (the client it sends normal operations over) when `Queue#close` is called. This defaults to `true` for normal usage, and `false` if an existing `RedisClient` object was provided to the `redis` option.
 - `redisScanCount`: number. For setting the value of the `SSCAN` Redis command used in `Queue#getJobs` for succeeded and failed job types.
+- `clearMissingJobs`: boolean. Enable to clear out job references if data is missing.
 
 ### Properties
 

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -18,6 +18,7 @@ module.exports = {
   removeOnSuccess: false,
   removeOnFailure: false,
   redisScanCount: 100,
+  clearMissingJobs: false,
 
   // quitCommandClient is dependent on whether the redis setting was an actual
   // redis client, or just configuration options to create such a client.

--- a/lib/job.js
+++ b/lib/job.js
@@ -28,7 +28,9 @@ class Job extends Emitter {
       .then((data) =>
         data
           ? Job.fromData(queue, jobId, data)
-          : queue.removeJob(jobId).then(() => null)
+          : queue.settings.clearMissingJobs
+          ? queue.removeJob(jobId).then(() => null)
+          : null
       );
 
     if (cb) helpers.asCallback(promise, cb);

--- a/lib/job.js
+++ b/lib/job.js
@@ -25,7 +25,11 @@ class Job extends Emitter {
           client.hget(queue.toKey('jobs'), jobId, done)
         )
       )
-      .then((data) => (data ? Job.fromData(queue, jobId, data) : null));
+      .then((data) =>
+        data
+          ? Job.fromData(queue, jobId, data)
+          : queue.removeJob(jobId).then(() => null)
+      );
 
     if (cb) helpers.asCallback(promise, cb);
     return promise;

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -676,18 +676,18 @@ class Queue extends Emitter {
             return;
           }
 
-          this.running += 1;
-          this.queued -= 1;
-          if (this.running + this.queued < this.concurrency) {
-            this.queued += 1;
-            setImmediate(jobTick);
-          }
-
           if (!job) {
             // Per comment in Queue#_waitForJob, this branch is possible when
             // the job is removed before processing can take place, but after
             // being initially acquired.
             return;
+          }
+
+          this.running += 1;
+          this.queued -= 1;
+          if (this.running + this.queued < this.concurrency) {
+            this.queued += 1;
+            setImmediate(jobTick);
           }
 
           return this._runJob(job).then((results) => {

--- a/test/queue-test.js
+++ b/test/queue-test.js
@@ -1440,7 +1440,7 @@ describe('Queue', (it) => {
     });
 
     it('clears a waiting job that is missing data', async (t) => {
-      const queue = t.context.makeQueue();
+      const queue = t.context.makeQueue({clearMissingJobs: true});
 
       const job = await queue.createJob({foo: 'first'}).save();
 

--- a/test/queue-test.js
+++ b/test/queue-test.js
@@ -1445,8 +1445,8 @@ describe('Queue', (it) => {
       const job = await queue.createJob({foo: 'first'}).save();
 
       // Delete the job's data from redis
-      await new Promise((resolve) =>
-        queue.client.hdel(queue.toKey('jobs'), job.id, resolve)
+      await helpers.callAsync((done) =>
+        queue.client.hdel(queue.toKey('jobs'), job.id, done)
       );
 
       // Create a second job
@@ -1466,12 +1466,10 @@ describe('Queue', (it) => {
 
       // By default the job id would have been moved to the active list (soon to stall)
       // So we just check it is no longer there
-      await new Promise((resolve) =>
-        queue.client.llen(queue.toKey('active'), (_, active) => {
-          t.is(active, 0);
-          resolve();
-        })
+      const active = await helpers.callAsync((done) =>
+        queue.client.llen(queue.toKey('active'), done)
       );
+      t.is(active, 0);
     });
 
     it('processes a job that auto-retries', async (t) => {

--- a/test/queue-test.js
+++ b/test/queue-test.js
@@ -1439,6 +1439,41 @@ describe('Queue', (it) => {
       t.is(err.message, `Job ${job.id} timed out (10 ms)`);
     });
 
+    it('clears a waiting job that is missing data', async (t) => {
+      const queue = t.context.makeQueue();
+
+      const job = await queue.createJob({foo: 'first'}).save();
+
+      // Delete the job's data from redis
+      await new Promise((resolve) =>
+        queue.client.hdel(queue.toKey('jobs'), job.id, resolve)
+      );
+
+      // Create a second job
+      await queue.createJob({foo: 'second'}).save();
+
+      const succeeded = helpers.waitOn(queue, 'succeeded');
+
+      // Now run the queue
+      let callCount = 0;
+      queue.process(async (processedJob) => {
+        callCount += 1;
+        t.is(processedJob.data.foo, 'second');
+      });
+
+      await succeeded;
+      t.is(callCount, 1);
+
+      // By default the job id would have been moved to the active list (soon to stall)
+      // So we just check it is no longer there
+      await new Promise((resolve) =>
+        queue.client.llen(queue.toKey('active'), (_, active) => {
+          t.is(active, 0);
+          resolve();
+        })
+      );
+    });
+
     it('processes a job that auto-retries', async (t) => {
       const queue = t.context.makeQueue();
       const retries = 1;


### PR DESCRIPTION
In certain pathological cases, job data can get lost (to be honest not totally sure how). It seems sensible to just drop the job if we find this, rather than the current behaviour which is to constantly send the job through a `waiting => active => waiting` loop.