### PR TITLE
Ensure we don't call `unpack` with too many elements

### DIFF
--- a/lib/lua/checkStalledJobs.lua
+++ b/lib/lua/checkStalledJobs.lua
@@ -40,9 +40,10 @@ if next(stalling) ~= nil then
   -- hog the job consumers and starve the whole system. not a great situation
   -- to be in, but this is fairer.
   local pushed = 0
+  local nStalled = #stalled
   -- don't lpush zero jobs (the redis command will fail)
-  while pushed < #stalled do
-    redis.call("lpush", KEYS[3], unpack(stalled, pushed + 1, math.min(pushed + maxUnpack, #stalled)))
+  while pushed < nStalled do
+    redis.call("lpush", KEYS[3], unpack(stalled, pushed + 1, math.min(pushed + maxUnpack, nStalled)))
     pushed = pushed + maxUnpack
   end
   redis.call("del", KEYS[2])
@@ -50,8 +51,9 @@ end
 
 -- copy currently active jobs into stalling set
 local actives, added = redis.call("lrange", KEYS[4], 0, -1), 0
-while added < #actives do
-  redis.call("sadd", KEYS[2], unpack(actives, added + 1, math.min(added + maxUnpack, #actives)))
+local nActives = #actives
+while added < nActives do
+  redis.call("sadd", KEYS[2], unpack(actives, added + 1, math.min(added + maxUnpack, nActives)))
   added = added + maxUnpack
 end
 

--- a/lib/lua/checkStalledJobs.lua
+++ b/lib/lua/checkStalledJobs.lua
@@ -41,7 +41,7 @@ if next(stalling) ~= nil then
   -- to be in, but this is fairer.
   local pushed = 0
   -- don't lpush zero jobs (the redis command will fail)
-  while (pushed < #stalled) do
+  while pushed < #stalled do
     redis.call("lpush", KEYS[3], unpack(stalled, pushed + 1, math.min(pushed + maxUnpack, #stalled)))
     pushed = pushed + maxUnpack
   end
@@ -50,7 +50,7 @@ end
 
 -- copy currently active jobs into stalling set
 local actives, added = redis.call("lrange", KEYS[4], 0, -1), 0
-while (added < #actives) do
+while added < #actives do
   redis.call("sadd", KEYS[2], unpack(actives, added + 1, math.min(added + maxUnpack, #actives)))
   added = added + maxUnpack
 end


### PR DESCRIPTION
If there are many many stalled jobs, we can hit lua's built in stack limit when trying to unpack them all in the `checkStalledJobs` script. This does the unpacking in batches.