### PR TITLE
fix(types): fix typescript definitions errors

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ declare class BeeQueue<T = any> extends EventEmitter {
   jobs: any;
   paused: boolean;
   settings: any;
-  backoffStrategies: Map<string, (job: BeeQueue.Job) => number>;
+  backoffStrategies: Map<string, (job: BeeQueue.Job<T>) => number>;
 
   constructor(name: string, settings?: BeeQueue.QueueSettings);
 
@@ -116,10 +116,7 @@ declare namespace BeeQueue {
 
     setId(id: string): this;
     retries(n: number): this;
-    backoff(
-      strategy: keyof typeof this.backoffStrategies,
-      delayFactor?: number
-    ): this;
+    backoff(strategy: string, delayFactor?: number): this;
     delayUntil(dateOrTimestamp: Date | number): this;
     timeout(milliseconds: number): this;
     save(): Promise<this>;


### PR DESCRIPTION
Should resolve the new errors introduced in v1.3.0 via #134.

Fixes #310.