### PR TITLE
fix: handle script reinstantiation during Redis failover

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -830,16 +830,40 @@ class Queue extends Emitter {
       args[i] = arguments[i];
     }
 
-    return this._commandable().then((client) => {
-      // Get the sha for the script after we're ready to avoid a race condition
-      // with the lua script loader.
-      args[0] = lua.shas[name];
+    return this._commandable()
+      .then((client) => {
+        // Get the sha for the script after we're ready to avoid a race
+        // condition with the lua script loader.
+        args[0] = lua.shas[name];
 
-      const promise = helpers.deferred();
-      args.push(promise.defer());
-      client.evalsha.apply(client, args);
-      return promise;
-    });
+        const promise = helpers.deferred();
+        args.push(promise.defer());
+        client.evalsha.apply(client, args);
+        return promise;
+      })
+      .catch((err) => {
+        // In cases where the Redis server fails over, the script cache is
+        // cleared (even when the cache itself is still intact.) We detect this
+        // condition and reload the scripts.
+        if (
+          err.name === 'ReplyError' &&
+          err.message === 'NOSCRIPT No matching script. Please use EVAL.'
+        ) {
+          return lua.buildCache(this.client).then((client) => {
+            // Try again.
+            // Get the sha for the script after we're ready to avoid a race
+            // condition with the lua script loader.
+            args[0] = lua.shas[name];
+
+            const promise = helpers.deferred();
+            args.push(promise.defer());
+            client.evalsha.apply(client, args);
+            return promise;
+          });
+        } else {
+          throw err;
+        }
+      });
   }
 }
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -11,6 +11,8 @@ const backoff = require('./backoff');
 const EagerTimer = require('./eager-timer');
 const finally_ = require('p-finally');
 
+const scriptCachePromises = new WeakMap();
+
 class Queue extends Emitter {
   constructor(name, settings) {
     super();
@@ -114,7 +116,7 @@ class Queue extends Emitter {
     ])
       .then(() => {
         if (this.settings.ensureScripts) {
-          return lua.buildCache(this.client);
+          return (scriptCachePromises = lua.buildCache(this.client));
         }
       })
       .then(() => {
@@ -830,39 +832,33 @@ class Queue extends Emitter {
       args[i] = arguments[i];
     }
 
+    function _evalScriptInner(client) {
+      const promise = helpers.deferred();
+      args.push(promise.defer());
+      client.evalsha.apply(client, args);
+      return promise;
+    }
+
     return this._commandable()
       .then((client) => {
         // Get the sha for the script after we're ready to avoid a race
         // condition with the lua script loader.
         args[0] = lua.shas[name];
-
-        const promise = helpers.deferred();
-        args.push(promise.defer());
-        client.evalsha.apply(client, args);
-        return promise;
+        return _evalScriptInner(client);
       })
       .catch((err) => {
         // In cases where the Redis server fails over, the script cache is
         // cleared (even when the cache itself is still intact.) We detect this
         // condition and reload the scripts.
-        if (
-          err.name === 'ReplyError' &&
-          err.message === 'NOSCRIPT No matching script. Please use EVAL.'
-        ) {
-          return lua.buildCache(this.client).then((client) => {
-            // Try again.
-            // Get the sha for the script after we're ready to avoid a race
-            // condition with the lua script loader.
-            args[0] = lua.shas[name];
-
-            const promise = helpers.deferred();
-            args.push(promise.defer());
-            client.evalsha.apply(client, args);
-            return promise;
-          });
-        } else {
+        if (err.code !== 'NOSCRIPT') {
           throw err;
         }
+        return scriptCachePromises.then(
+          this._commandable().then((client) => {
+            // Try again.
+            return _evalScriptInner(client);
+          })
+        );
       });
   }
 }


### PR DESCRIPTION
This PR helps handle script re-instantiation during Redis failover events (in AWS at least.) When swapping instances, the script cache disappears, even while keeping the contents of the Redis cache intact. At present, `bee-queue` only loads scripts during startup, which means that after failover events this `evalsha` call fails for already running bee-queue instances. This PR attempts to catch this error, re-instantiate the scripts on the new Redis server, and try again.

An alternative and less obtuse implementation could be to utilize [`SCRIPT EXISTS`](https://redis.io/commands/script-exists) to check before every `EVALSHA`, but that doubles the round trips to Redis on every run; instead we catch this odd edgecase and only try to re-instantiate them when we encounter it.

My javascript isn't great; I'd appreciate any and all checks for correctness, code quality & style, and things I just hadn't considered. As a result, I'm filing this as a draft to receive early feedback on implementation. I'll be testing this out more fully on localhost later; at present, `npm test` passes all 140 tests.