### PR TITLE
2.0: drop node 4/6, callbacks; use ioredis

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,16 +1,13 @@
 {
+  "parserOptions": {
+    "ecmaVersion": 2017
+  },
   "env": {
     "node": true,
     "es6": true
   },
   "extends": ["plugin:prettier/recommended"],
   "overrides": [
-    {
-      "files": ["lib/**"],
-      "rules": {
-        "max-len": "error"
-      }
-    },
     {
       "files": ["benchmark/**", "examples/**"],
       "parserOptions": {
@@ -45,7 +42,7 @@
     "eol-last": "error",
     "eqeqeq": ["error", "smart"],
     "key-spacing": "warn",
-    "new-cap": ["error", {"capIsNew": false}],
+    "new-cap": ["error", { "capIsNew": false }],
     "no-console": "error",
     "no-floating-decimal": "error",
     "no-inner-declarations": "error",
@@ -56,24 +53,18 @@
     "no-trailing-spaces": "error",
     "no-undef": "error",
     "no-underscore-dangle": "off",
-    "no-unused-vars": ["error", {"vars": "all", "args": "after-used"}],
+    "no-unused-vars": ["error", { "vars": "all", "args": "after-used" }],
     "no-use-before-define": ["error", "nofunc"],
     "no-var": "error",
     "no-warning-comments": [
       "warn",
       {"terms": ["todo"], "location": "anywhere"}
     ],
-    "object-curly-spacing": ["error", "never"],
-    "prefer-const": ["error", {"destructuring": "all"}],
-    "quotes": ["error", "single"],
+    "prefer-const": ["error", { "destructuring": "all" }],
     "semi": ["error", "always"],
-    "semi-spacing": ["error", {"before": false, "after": true}],
+    "semi-spacing": ["error", { "before": false, "after": true }],
     "keyword-spacing": "error",
     "space-before-blocks": "error",
-    "space-before-function-paren": [
-      "error",
-      {"anonymous": "always", "named": "never"}
-    ],
     "space-in-parens": "error",
     "space-infix-ops": "error",
     "strict": "off"

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -31,7 +31,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [4.0.x, 8.x, 10.x, 12.x, 14.x]
+        node-version: [8.x, 10.x, 12.x, 14.x]
         include:
           - node-version: 14.x
             report-coverage: true

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -38,10 +38,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        with:
-          # For commitlint; ideally this would only check out the feature branch's history, but
-          # that's not currently an option.
-          fetch-depth: ${{ github.event_name == 'push' }}
       - name: Cache dependencies
         id: cache
         uses: actions/cache@v2
@@ -63,15 +59,38 @@ jobs:
       - run: npm run ci --if-present
         env:
           BEE_QUEUE_TEST_REDIS: redis://localhost:6379
-      - run: npm run ci:commitlint
-        if: "github.event_name != 'push'"
-        env:
-          GITHUB_BASE_REF: ${{ github.event.pull_request.base.ref }}
       - name: Report to Coveralls
         uses: coverallsapp/github-action@master
         if: matrix.report-coverage
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  commitlint:
+    # https://github.community/t/github-actions-does-not-respect-skip-ci/17325/9
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    runs-on: ubuntu-latest
+
+    needs: [test]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # For commitlint; ideally this would only check out the feature branch's history, but
+          # that's not currently an option.
+          fetch-depth: ${{ github.event_name == 'push' }}
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+      - name: Restore dependencies
+        id: cache
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+      - run: npm run ci:commitlint
+        if: "github.event_name != 'push'"
+        env:
+          GITHUB_BASE_REF: ${{ github.event.pull_request.base.ref }}
 
   release:
     # https://github.community/t/github-actions-does-not-respect-skip-ci/17325/9
@@ -79,7 +98,6 @@ jobs:
     runs-on: ubuntu-latest
 
     needs: [test]
-
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,7 +4,6 @@
   "semi": true,
   "singleQuote": true,
   "trailingComma": "es5",
-  "bracketSpacing": false,
   "arrowParens": "always",
   "endOfLine": "lf"
 }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A simple, fast, robust job/task queue for Node.js, backed by Redis.
 const Queue = require('bee-queue');
 const queue = new Queue('example');
 
-const job = queue.createJob({x: 2, y: 3});
+const job = queue.createJob({ x: 2, y: 3 });
 job.save();
 job.on('succeeded', (result) => {
   console.log(`Received result for job ${job.id}: ${result}`);
@@ -138,7 +138,7 @@ Jobs are created using `Queue.createJob(data)`, which returns a [Job](#job) obje
 Jobs have a chaining API for configuring the Job, and `.save([cb])` method to save the job into Redis and enqueue it for processing:
 
 ```js
-const job = addQueue.createJob({x: 2, y: 3});
+const job = addQueue.createJob({ x: 2, y: 3 });
 job
   .timeout(3000)
   .retries(2)
@@ -160,7 +160,10 @@ Normally, creating and saving jobs blocks the underlying redis client for the fu
 
 ```js
 addQueue
-  .saveAll([addQueue.createJob({x: 3, y: 4}), addQueue.createJob({x: 4, y: 5})])
+  .saveAll([
+    addQueue.createJob({ x: 3, y: 4 }),
+    addQueue.createJob({ x: 4, y: 5 }),
+  ])
   .then((errors) => {
     // The errors value is a Map associating Jobs with Errors. This will often be an empty Map.
   });
@@ -209,7 +212,7 @@ subQueue.process(10, function (job, done) {
 Handlers can send progress reports, which will be received as events on the original job instance:
 
 ```js
-const job = addQueue.createJob({x: 2, y: 3}).save();
+const job = addQueue.createJob({ x: 2, y: 3 }).save();
 job.on('progress', (progress) => {
   console.log(
     `Job ${job.id} reported progress: page ${progress.page} / ${progress.totalPages}`
@@ -218,9 +221,9 @@ job.on('progress', (progress) => {
 
 addQueue.process(async (job) => {
   // do some work
-  job.reportProgress({page: 3, totalPages: 11});
+  job.reportProgress({ page: 3, totalPages: 11 });
   // do more work
-  job.reportProgress({page: 9, totalPages: 11});
+  job.reportProgress({ page: 9, totalPages: 11 });
   // do the rest
 });
 ```
@@ -513,12 +516,12 @@ Be careful with this method; most potential uses would be better served by job e
 #### Queue#getJobs(type, page, [cb])
 
 ```js
-queue.getJobs('waiting', {start: 0, end: 25}).then((jobs) => {
+queue.getJobs('waiting', { start: 0, end: 25 }).then((jobs) => {
   const jobIds = jobs.map((job) => job.id);
   console.log(`Job ids: ${jobIds.join(' ')}`);
 });
 
-queue.getJobs('failed', {size: 100}).then((jobs) => {
+queue.getJobs('failed', { size: 100 }).then((jobs) => {
   const jobIds = jobs.map((job) => job.id);
   console.log(`Job ids: ${jobIds.join(' ')}`);
 });

--- a/benchmark/bq/harness.js
+++ b/benchmark/bq/harness.js
@@ -32,7 +32,7 @@ function reef(n = 1) {
 module.exports = (options) => {
   return new Promise((resolve) => {
     queue.on('ready', () => {
-      const {done, next} = reef(options.numRuns);
+      const { done, next } = reef(options.numRuns);
 
       queue.process(options.concurrency, () => {
         next();
@@ -41,7 +41,7 @@ module.exports = (options) => {
 
       const startTime = Date.now();
       for (let i = 0; i < options.numRuns; ++i) {
-        queue.createJob({i}).save();
+        queue.createJob({ i }).save();
       }
       return done.then(() => {
         const elapsed = Date.now() - startTime;

--- a/benchmark/bull/harness.js
+++ b/benchmark/bull/harness.js
@@ -19,7 +19,7 @@ function reef(n = 1) {
 
 module.exports = (options) => {
   return queue.isReady().then(() => {
-    const {done, next} = reef(options.numRuns);
+    const { done, next } = reef(options.numRuns);
 
     queue.process(options.concurrency, () => {
       next();
@@ -28,7 +28,7 @@ module.exports = (options) => {
 
     const startTime = Date.now();
     for (let i = 0; i < options.numRuns; ++i) {
-      queue.add({i}, {removeOnComplete: true});
+      queue.add({ i }, { removeOnComplete: true });
     }
     return done.then(() => {
       const elapsed = Date.now() - startTime;

--- a/benchmark/kue/harness.js
+++ b/benchmark/kue/harness.js
@@ -18,7 +18,7 @@ function reef(n = 1) {
 }
 
 module.exports = (options) => {
-  const {done, next} = reef(options.numRuns);
+  const { done, next } = reef(options.numRuns);
 
   queue.process('test', options.concurrency, (job, jobDone) => {
     next();
@@ -27,7 +27,7 @@ module.exports = (options) => {
 
   const startTime = Date.now();
   for (let i = 0; i < options.numRuns; ++i) {
-    queue.create('test', {i}).removeOnComplete(true).save();
+    queue.create('test', { i }).removeOnComplete(true).save();
   }
   return done.then(() => {
     const elapsed = Date.now() - startTime;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,8 @@
 /// <reference types="node" />
 /// <reference types="redis" />
 
-import {EventEmitter} from 'events';
-import {ClientOpts, RedisClient} from 'redis';
+import { EventEmitter } from 'events';
+import { ClientOpts, RedisClient } from 'redis';
 
 declare class BeeQueue<T = any> extends EventEmitter {
   name: string;

--- a/lib/eager-timer.js
+++ b/lib/eager-timer.js
@@ -19,7 +19,7 @@ class EagerTimer extends Emitter {
     this._timer = null;
 
     this._stopped = false;
-    this._boundTrigger = this._trigger.bind(this);
+    this._boundTrigger = () => this._trigger();
   }
 
   schedule(time) {

--- a/lib/eager-timer.js
+++ b/lib/eager-timer.js
@@ -11,7 +11,7 @@ class EagerTimer extends Emitter {
     super();
 
     if (!Number.isSafeInteger(maxDelay) || maxDelay <= 0) {
-      throw new Error('maximum delay must be a positive integer');
+      throw new TypeError('maximum delay must be a positive integer');
     }
 
     this._maxDelay = maxDelay;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,9 +1,30 @@
 'use strict';
 
-const hasOwn = Object.prototype.hasOwnProperty;
+function delay(time) {
+  return new Promise((resolve) => setTimeout(resolve, time));
+}
 
-function has(object, name) {
-  return hasOwn.call(object, name);
+// borrowed/adapted from promise-callbacks
+function waitOn(emitter, event) {
+  return new Promise((resolve, reject) => {
+    function unbind() {
+      emitter.removeListener('error', onError);
+      emitter.removeListener(event, onEvent);
+    }
+
+    function onEvent(value) {
+      unbind();
+      resolve(value);
+    }
+
+    function onError(err) {
+      unbind();
+      reject(err);
+    }
+
+    emitter.on('error', onError);
+    emitter.on(event, onEvent);
+  });
 }
 
 /**
@@ -22,16 +43,61 @@ function finallyRejectsWithInitial(promise, fn) {
   );
 }
 
-const promiseUtils = require('promise-callbacks');
+// shamelessly stolen from promise-callbacks
+function withTimeout(promise, timeLimit, message) {
+  let timeout;
+  const timeoutPromise = new Promise((resolve, reject) => {
+    // Instantiate the error here to capture a more useful stack trace.
+    const error =
+      message instanceof Error
+        ? message
+        : new Error(message || 'Operation timed out.');
+    timeout = setTimeout(reject, timeLimit, error);
+  });
+  // lol classic case of wanting `Promise.prototype.finally` right here
+  return Promise.race([promise, timeoutPromise]).then(
+    (value) => {
+      clearTimeout(timeout);
+      return value;
+    },
+    (err) => {
+      clearTimeout(timeout);
+      throw err;
+    }
+  );
+}
+
+class Defer {
+  constructor() {
+    this.promise = new Promise((resolve, reject) => {
+      this.resolve = resolve;
+      this.reject = reject;
+    });
+  }
+}
+
+function* zip(...iterables) {
+  const iterators = iterables.map((iter) => iter[Symbol.iterator]());
+  for (;;) {
+    let isDone = 0;
+    const item = iterators.map((iter) => {
+      const { value, done } = iter.next();
+      isDone += done;
+      return value;
+    });
+    if (isDone) {
+      if (isDone === iterators.length) break;
+      throw new Error('mismatched iterable lengths');
+    }
+    yield item;
+  }
+}
 
 module.exports = {
-  asCallback: promiseUtils.asCallback,
-  callAsync: promiseUtils.callAsync,
-  deferred: promiseUtils.deferred,
-  delay: promiseUtils.delay,
+  defer: () => new Defer(),
+  delay,
   finallyRejectsWithInitial,
-  has,
-  waitOn: promiseUtils.waitOn,
-  withTimeout: promiseUtils.withTimeout,
-  wrapAsync: promiseUtils.wrapAsync,
+  waitOn,
+  withTimeout,
+  zip,
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -76,28 +76,10 @@ class Defer {
   }
 }
 
-function* zip(...iterables) {
-  const iterators = iterables.map((iter) => iter[Symbol.iterator]());
-  for (;;) {
-    let isDone = 0;
-    const item = iterators.map((iter) => {
-      const { value, done } = iter.next();
-      isDone += done;
-      return value;
-    });
-    if (isDone) {
-      if (isDone === iterators.length) break;
-      throw new Error('mismatched iterable lengths');
-    }
-    yield item;
-  }
-}
-
 module.exports = {
   defer: () => new Defer(),
   delay,
   finallyRejectsWithInitial,
   waitOn,
   withTimeout,
-  zip,
 };

--- a/lib/job.js
+++ b/lib/job.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Emitter = require('events').EventEmitter;
-const helpers = require('./helpers');
 
 class Job extends Emitter {
   constructor(queue, jobId, data, options) {
@@ -17,18 +16,11 @@ class Job extends Emitter {
     this.status = 'created';
   }
 
-  static fromId(queue, jobId, cb) {
-    const promise = queue
-      ._commandable()
-      .then((client) =>
-        helpers.callAsync((done) =>
-          client.hget(queue.toKey('jobs'), jobId, done)
-        )
-      )
-      .then((data) => (data ? Job.fromData(queue, jobId, data) : null));
-
-    if (cb) helpers.asCallback(promise, cb);
-    return promise;
+  static async fromId(queue, jobId) {
+    const client = await queue._commandable();
+    const data = await client.hget(queue.toKey('jobs'), jobId);
+    if (!data) return null;
+    return Job.fromData(queue, jobId, data);
   }
 
   static fromData(queue, jobId, data) {
@@ -49,12 +41,12 @@ class Job extends Emitter {
 
   // For Queue#saveAll, this method is guaranteed to invoke evalScript
   // synchronously.
-  _save(evalScript) {
-    const toKey = this.queue.toKey.bind(this.queue);
+  async _save(evalScript) {
+    const toKey = (str) => this.queue.toKey(str);
 
-    let promise;
+    let jobId;
     if (this.options.delay) {
-      promise = evalScript([
+      jobId = await evalScript([
         'addDelayedJob',
         4,
         toKey('id'),
@@ -67,16 +59,10 @@ class Job extends Emitter {
       ]);
 
       if (this.queue.settings.activateDelayedJobs) {
-        promise = promise.then((jobId) => {
-          // Only reschedule if the job was actually created.
-          if (jobId) {
-            this.queue._delayedTimer.schedule(this.options.delay);
-          }
-          return jobId;
-        });
+        if (jobId) this.queue._delayedTimer.schedule(this.options.delay);
       }
     } else {
-      promise = evalScript([
+      jobId = await evalScript([
         'addJob',
         3,
         toKey('id'),
@@ -87,22 +73,17 @@ class Job extends Emitter {
       ]);
     }
 
-    return promise.then((jobId) => {
-      this.id = jobId;
-      // If the jobId is not null, then store the job in the job map.
-      if (jobId && this.queue.settings.storeJobs) {
-        this.queue.jobs.set(jobId, this);
-      }
-      return this;
-    });
+    this.id = jobId;
+    // If the jobId is not null, then store the job in the job map.
+    if (jobId && this.queue.settings.storeJobs) {
+      this.queue.jobs.set(jobId, this);
+    }
+    return this;
   }
 
-  save(cb) {
-    const promise = this._save((args) =>
-      this.queue._evalScript.apply(this.queue, args)
-    );
+  save() {
+    const promise = this._save((args) => this.queue._evalScript(...args));
 
-    if (cb) helpers.asCallback(promise, cb);
     return promise;
   }
 
@@ -159,66 +140,38 @@ class Job extends Emitter {
     return this;
   }
 
-  reportProgress(progress, cb) {
-    let promise;
-    if (progress != null) {
-      this.progress = progress;
-      promise = this.queue._commandable().then((client) =>
-        helpers.callAsync((done) =>
-          client.publish(
-            this.queue.toKey('events'),
-            JSON.stringify({
-              id: this.id,
-              event: 'progress',
-              data: progress,
-            }),
-            done
-          )
-        )
-      );
-    } else {
-      promise = Promise.reject(new Error('Progress cannot be empty'));
+  async reportProgress(progress) {
+    if (progress == null) {
+      throw new Error('Progress cannot be empty');
     }
-
-    if (cb) helpers.asCallback(promise, cb);
-    return promise;
+    this.progress = progress;
+    const client = await this.queue._commandable();
+    const payload = JSON.stringify({
+      id: this.id,
+      event: 'progress',
+      data: progress,
+    });
+    return client.publish(this.queue.toKey('events'), payload);
   }
 
-  remove(cb) {
-    const promise = this.queue.removeJob(this.id).then(() => this);
-    if (cb) helpers.asCallback(promise, cb);
-    return promise;
+  async remove() {
+    await this.queue.removeJob(this.id);
+    return this;
   }
 
-  retry(cb) {
-    const promise = this.queue
-      ._commandable()
-      .then((client) =>
-        helpers.callAsync((done) =>
-          client
-            .multi()
-            .srem(this.queue.toKey('failed'), this.id)
-            .lpush(this.queue.toKey('waiting'), this.id)
-            .exec(done)
-        )
-      );
-
-    if (cb) helpers.asCallback(promise, cb);
-    return promise;
+  async retry() {
+    const client = await this.queue._commandable();
+    return client
+      .multi()
+      .srem(this.queue.toKey('failed'), this.id)
+      .lpush(this.queue.toKey('waiting'), this.id)
+      .exec();
   }
 
-  isInSet(set, cb) {
-    const promise = this.queue
-      ._commandable()
-      .then((client) =>
-        helpers.callAsync((done) =>
-          client.sismember(this.queue.toKey(set), this.id, done)
-        )
-      )
-      .then((result) => result === 1);
-
-    if (cb) helpers.asCallback(promise, cb);
-    return promise;
+  async isInSet(set) {
+    const client = await this.queue._commandable();
+    const result = await client.sismember(this.queue.toKey(set), this.id);
+    return result === 1;
   }
 }
 

--- a/lib/lua/index.js
+++ b/lib/lua/index.js
@@ -4,26 +4,23 @@ const fs = require('fs');
 const crypto = require('crypto');
 const path = require('path');
 
-const helpers = require('../helpers');
-
-const promisify = require('promise-callbacks').promisify;
+const { promisify } = require('util');
 
 const scripts = {};
 const shas = {};
 let scriptsRead = false;
 let scriptsPromise = null;
 
-const readFile = promisify.methods(fs, ['readFile']).readFile;
-const readDir = promisify.methods(fs, ['readdir']).readdir;
+const readFile = promisify(fs.readFile);
+const readDir = promisify(fs.readdir);
 
-function readScript(file) {
-  return readFile(path.join(__dirname, file), 'utf8').then((script) => {
-    const name = file.slice(0, -4);
-    scripts[name] = script;
-    const hash = crypto.createHash('sha1');
-    hash.update(script);
-    shas[name] = hash.digest('hex');
-  });
+async function readScript(file) {
+  const script = await readFile(path.join(__dirname, file), 'utf8');
+  const name = file.slice(0, -4);
+  scripts[name] = script;
+  const hash = crypto.createHash('sha1');
+  hash.update(script);
+  shas[name] = hash.digest('hex');
 }
 
 function readScripts() {
@@ -36,24 +33,17 @@ function readScripts() {
     .then(() => scripts));
 }
 
-function loadScriptIfMissing(client, scriptKey) {
-  return helpers
-    .callAsync((done) => client.script('exists', shas[scriptKey], done))
-    .then((exists) =>
-      exists[0] === 0
-        ? helpers.callAsync((done) =>
-            client.script('load', scripts[scriptKey], done)
-          )
-        : null
-    );
+async function loadScriptIfMissing(client, scriptKey) {
+  const [exists] = await client.script('exists', shas[scriptKey]);
+  if (exists !== 0) return null;
+  return client.script('load', scripts[scriptKey]);
 }
 
-function buildCache(client) {
+async function buildCache(client) {
   // We could theoretically pipeline this, but it's pretty insignificant.
-  return readScripts().then(() =>
-    Promise.all(
-      Object.keys(shas).map((key) => loadScriptIfMissing(client, key))
-    )
+  await readScripts();
+  await Promise.all(
+    Object.keys(shas).map((key) => loadScriptIfMissing(client, key))
   );
 }
 

--- a/lib/lua/removeJob.lua
+++ b/lib/lua/removeJob.lua
@@ -1,23 +1,27 @@
 --[[
-key 1 -> bq:test:succeeded
-key 2 -> bq:test:failed
-key 3 -> bq:test:waiting
-key 4 -> bq:test:active
-key 5 -> bq:test:stalling
-key 6 -> bq:test:jobs
-key 7 -> bq:test:delayed
+key 1 -> bq:test:jobs
+key 2 -> bq:test:waiting
+key 3 -> bq:test:active
+key 4 -> bq:test:succeeded
+key 5 -> bq:test:failed
+key 6 -> bq:test:delayed
+key 7 -> bq:test:stalling
+
 arg 1 -> jobId
 ]]
 
+local rcall = redis.call
 local jobId = ARGV[1]
 
-if (redis.call("sismember", KEYS[1], jobId) + redis.call("sismember", KEYS[2], jobId)) == 0 then
-  redis.call("lrem", KEYS[3], 0, jobId)
-  redis.call("lrem", KEYS[4], 0, jobId)
+rcall("hdel", KEYS[1], jobId)
+
+-- if neither succeeded nor failed, must be either waiting or active
+if rcall("sismember", KEYS[4], jobId) == 0 and rcall("sismember", KEYS[5], jobId) == 0 then
+  rcall("lrem", KEYS[2], 0, jobId)
+  rcall("lrem", KEYS[3], 0, jobId)
 end
 
-redis.call("srem", KEYS[1], jobId)
-redis.call("srem", KEYS[2], jobId)
-redis.call("srem", KEYS[5], jobId)
-redis.call("hdel", KEYS[6], jobId)
-redis.call("zrem", KEYS[7], jobId)
+rcall("srem", KEYS[4], jobId)
+rcall("srem", KEYS[5], jobId)
+rcall("zrem", KEYS[6], jobId) -- zrem for delayed set
+rcall("srem", KEYS[7], jobId)

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -71,12 +71,14 @@ class Queue extends Emitter {
       this._delayedTimer.on('trigger', () => this._activateDelayed());
     }
 
-    const makeClient = async (clientName, createNew) => {
-      const client = await redis.createClient(this.settings.redis, createNew);
+    const makeClient = async (createNew, getClientID) => {
+      const client = await redis.createClient(this.settings.redis, {
+        createNew,
+        getClientID,
+      });
       // This event gets cleaned up and removed in Queue#close for the
       // primary client if quitCommandClient is disabled.
       client.on('error', this._emitError);
-      this[clientName] = client;
       return client;
     };
 
@@ -84,7 +86,8 @@ class Queue extends Emitter {
       if (!this.settings.getEvents && !this.settings.activateDelayedJobs) {
         return;
       }
-      const eclient = await makeClient('eclient', true);
+      const eclient = await makeClient(true, false);
+      this.eclient = eclient;
       eclient.on('message', (channel, message) =>
         this._onMessage(channel, message)
       );
@@ -103,8 +106,10 @@ class Queue extends Emitter {
     // Wait for needed client connections, event subs, and Lua script caching
     this._ready = (async () => {
       await Promise.all([
-        makeClient('client', false),
-        this.settings.isWorker ? makeClient('bclient', true) : null,
+        makeClient(false, false).then((client) => (this.client = client)),
+        this.settings.isWorker
+          ? makeClient(true, true).then((bclient) => (this.bclient = bclient))
+          : null,
         makeEventClient(),
       ]);
       if (this.settings.ensureScripts) {
@@ -190,10 +195,10 @@ class Queue extends Emitter {
 
     const drain = () =>
       helpers.finallyRejectsWithInitial(this._ready, async () => {
-        // Stop the blocking connection, ensures that we don't accept additional
-        // jobs while waiting for the ongoing jobs to terminate.
+        // Stop the blocking connection, to ensure that we don't accept
+        // additional jobs while waiting for the ongoing jobs to terminate.
         if (this.settings.isWorker) {
-          redis.disconnect(this.bclient);
+          await redis.cleanDisconnect(this.bclient, this.client);
         }
 
         // Wait for all the jobs to complete. Ignore job errors during shutdown.
@@ -217,8 +222,11 @@ class Queue extends Emitter {
         clients.push(this.eclient);
       }
 
-      // TODO: can this command fail?
-      return Promise.all(clients.map((client) => client.quit()));
+      return Promise.all(
+        clients.map((client) =>
+          client.quit().catch(() => redis.disconnect(client))
+        )
+      );
     };
 
     this._closed = helpers.finallyRejectsWithInitial(

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -24,7 +24,7 @@ class Queue extends Emitter {
     this._closed = null;
     this._isClosed = false;
 
-    this._emitError = (err) => void this.emit('error', err);
+    this._emitError = this.emit.bind(this, 'error');
     this._emitErrorAfterTick = (err) =>
       void process.nextTick(() => this.emit('error', err));
 
@@ -55,6 +55,8 @@ class Queue extends Emitter {
       this.settings.redis = Object.assign({}, this.settings.redis, {
         path: this.settings.redis.socket,
       });
+    } else if (typeof this.settings.redis === 'string') {
+      this.settings.redis = { url: this.settings.redis };
     }
 
     // By default, if we're given a redis client and no additional instructions,
@@ -71,11 +73,15 @@ class Queue extends Emitter {
       this._delayedTimer.on('trigger', () => this._activateDelayed());
     }
 
-    const makeClient = async (createNew, getClientID) => {
-      const client = await redis.createClient(this.settings.redis, {
-        createNew,
-        getClientID,
-      });
+    const makeClient = async (createNew, getClientID, optionOverrides) => {
+      const settings = this.settings.redis;
+      const client = await redis.createClient(
+        optionOverrides ? { ...settings, ...optionOverrides } : settings,
+        {
+          createNew,
+          getClientID,
+        }
+      );
       // This event gets cleaned up and removed in Queue#close for the
       // primary client if quitCommandClient is disabled.
       client.on('error', this._emitError);
@@ -108,7 +114,11 @@ class Queue extends Emitter {
       await Promise.all([
         makeClient(false, false).then((client) => (this.client = client)),
         this.settings.isWorker
-          ? makeClient(true, true).then((bclient) => (this.bclient = bclient))
+          ? makeClient(true, true, {
+              // This would interfere with our ability to capture the client ID
+              // on reconnection.
+              autoResendUnfulfilledCommands: false,
+            }).then((bclient) => (this.bclient = bclient))
           : null,
         makeEventClient(),
       ]);
@@ -198,6 +208,7 @@ class Queue extends Emitter {
         // Stop the blocking connection, to ensure that we don't accept
         // additional jobs while waiting for the ongoing jobs to terminate.
         if (this.settings.isWorker) {
+          // TODO: separate timeout?
           await redis.cleanDisconnect(this.bclient, this.client);
         }
 
@@ -477,7 +488,7 @@ class Queue extends Emitter {
       try {
         successData = await promise;
       } catch (err) {
-        failureErr = err || new Error('unspecified job error');
+        failureErr = err;
       }
       completed = true;
       if (psTimeout) {
@@ -503,7 +514,6 @@ class Queue extends Emitter {
   _preventStall(jobId) {
     // todo figure out coverage/refactor here
     const promise = this.client.srem(this.toKey('stalling'), jobId);
-    /* istanbul ignore next: these errors are only redis or network errors */
     return promise.catch(this._emitErrorAfterTick);
   }
 
@@ -778,7 +788,9 @@ class Queue extends Emitter {
       })
     );
     const results = await batch.exec();
-    for (const [defer, [error, jobId]] of helpers.zip(defers, results)) {
+    for (let i = 0; i < defers.length; ++i) {
+      const defer = defers[i],
+        [error, jobId] = results[i];
       if (error) {
         defer.reject(error);
       } else {
@@ -798,25 +810,14 @@ class Queue extends Emitter {
       this.toKey('waiting'),
       Date.now(),
       this.settings.delayedDebounce
-    ).then(
-      (results) => {
-        const numRaised = results[0],
-          nextOpportunity = results[1];
-        if (numRaised) {
-          this.emit('raised jobs', numRaised);
-        }
-        this._delayedTimer.schedule(parseInt(nextOpportunity, 10));
-      },
-      /* istanbul ignore next */ (err) => {
-        // Handle aborted redis connections.
-        if (redis.isAbortError(err)) {
-          if (this.paused) return;
-          // Retry.
-          return this._activateDelayed();
-        }
-        this._emitErrorAfterTick(err);
+    ).then((results) => {
+      const numRaised = results[0],
+        nextOpportunity = results[1];
+      if (numRaised) {
+        this.emit('raised jobs', numRaised);
       }
-    );
+      this._delayedTimer.schedule(parseInt(nextOpportunity, 10));
+    }, this._emitErrorAfterTick);
   }
 
   toKey(str) {

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -9,7 +9,6 @@ const lua = require('./lua');
 const helpers = require('./helpers');
 const backoff = require('./backoff');
 const EagerTimer = require('./eager-timer');
-const finally_ = require('p-finally');
 
 class Queue extends Emitter {
   constructor(name, settings) {
@@ -69,60 +68,52 @@ class Queue extends Emitter {
       ? new EagerTimer(this.settings.nearTermWindow)
       : null;
     if (this._delayedTimer) {
-      this._delayedTimer.on('trigger', this._activateDelayed.bind(this));
+      this._delayedTimer.on('trigger', () => this._activateDelayed());
     }
 
-    const makeClient = (clientName, createNew) => {
-      return redis
-        .createClient(this.settings.redis, createNew)
-        .then((client) => {
-          // This event gets cleaned up and removed in Queue#close for the
-          // primary client if quitCommandClient is disabled.
-          client.on('error', this._emitError);
-          return (this[clientName] = client);
-        });
+    const makeClient = async (clientName, createNew) => {
+      const client = await redis.createClient(this.settings.redis, createNew);
+      // This event gets cleaned up and removed in Queue#close for the
+      // primary client if quitCommandClient is disabled.
+      client.on('error', this._emitError);
+      this[clientName] = client;
+      return client;
     };
 
-    let eventsPromise = null;
-
-    if (this.settings.getEvents || this.settings.activateDelayedJobs) {
-      eventsPromise = makeClient('eclient', true).then(() => {
-        this.eclient.on('message', this._onMessage.bind(this));
-        const channels = [];
-        if (this.settings.getEvents) {
-          channels.push(this.toKey('events'));
-        }
-        if (this.settings.activateDelayedJobs) {
-          channels.push(this.toKey('earlierDelayed'));
-        }
-        return Promise.all(
-          channels.map((channel) =>
-            helpers.callAsync((done) => this.eclient.subscribe(channel, done))
-          )
-        );
-      });
-    }
+    const makeEventClient = async () => {
+      if (!this.settings.getEvents && !this.settings.activateDelayedJobs) {
+        return;
+      }
+      const eclient = await makeClient('eclient', true);
+      eclient.on('message', (channel, message) =>
+        this._onMessage(channel, message)
+      );
+      const channels = [];
+      if (this.settings.getEvents) {
+        channels.push(this.toKey('events'));
+      }
+      if (this.settings.activateDelayedJobs) {
+        channels.push(this.toKey('earlierDelayed'));
+      }
+      return Promise.all(channels.map((channel) => eclient.subscribe(channel)));
+    };
 
     this._isReady = false;
 
-    // Wait for Lua scripts and client connections to load. Also wait for
-    // bclient and eclient/subscribe if they're needed.
-    this._ready = Promise.all([
-      // Make the clients
-      makeClient('client', false),
-      this.settings.isWorker ? makeClient('bclient', true) : null,
-      eventsPromise,
-    ])
-      .then(() => {
-        if (this.settings.ensureScripts) {
-          return lua.buildCache(this.client);
-        }
-      })
-      .then(() => {
-        this._isReady = true;
-        setImmediate(() => this.emit('ready'));
-        return this;
-      });
+    // Wait for needed client connections, event subs, and Lua script caching
+    this._ready = (async () => {
+      await Promise.all([
+        makeClient('client', false),
+        this.settings.isWorker ? makeClient('bclient', true) : null,
+        makeEventClient(),
+      ]);
+      if (this.settings.ensureScripts) {
+        await lua.buildCache(this.client);
+      }
+      this._isReady = true;
+      setImmediate(() => this.emit('ready'));
+      return this;
+    })();
   }
 
   _onMessage(channel, message) {
@@ -160,39 +151,29 @@ class Queue extends Emitter {
     return !this.paused;
   }
 
-  ready(cb) {
-    if (cb) {
-      helpers.asCallback(
-        this._ready.then(() => {}),
-        cb
-      );
-    }
-
+  ready() {
     return this._ready;
   }
 
-  _commandable(requireBlocking) {
+  async _commandable(requireBlocking) {
     if (requireBlocking ? this.paused : this._isClosed) {
-      return Promise.reject(new Error('closed'));
+      throw new Error('closed');
     }
 
     if (this._isReady) {
-      return Promise.resolve(requireBlocking ? this.bclient : this.client);
+      return requireBlocking ? this.bclient : this.client;
     }
 
-    return this._ready.then(() => this._commandable(requireBlocking));
+    await this._ready;
+    return this._commandable(requireBlocking);
   }
 
-  close(timeout, cb) {
-    if (typeof timeout === 'function') {
-      cb = timeout;
-      timeout = defaults['#close'].timeout;
-    } else if (!Number.isSafeInteger(timeout) || timeout <= 0) {
+  close(timeout) {
+    if (!Number.isSafeInteger(timeout) || timeout <= 0) {
       timeout = defaults['#close'].timeout;
     }
 
     if (this.paused) {
-      if (cb) helpers.asCallback(this._closed, cb);
       return this._closed;
     }
 
@@ -208,7 +189,7 @@ class Queue extends Emitter {
     }
 
     const drain = () =>
-      helpers.finallyRejectsWithInitial(this._ready, () => {
+      helpers.finallyRejectsWithInitial(this._ready, async () => {
         // Stop the blocking connection, ensures that we don't accept additional
         // jobs while waiting for the ongoing jobs to terminate.
         if (this.settings.isWorker) {
@@ -216,9 +197,9 @@ class Queue extends Emitter {
         }
 
         // Wait for all the jobs to complete. Ignore job errors during shutdown.
-        return Promise.all(
+        await Promise.all(
           Array.from(this.activeJobs, (promise) => promise.catch(() => {}))
-        ).then(() => {});
+        );
       });
 
     const cleanup = () => {
@@ -236,128 +217,101 @@ class Queue extends Emitter {
         clients.push(this.eclient);
       }
 
-      // node_redis' implementation of the QUIT command does not permit it to
-      // fail. We do not need to consider the case that the quit command aborts.
-      return Promise.all(
-        clients.map((client) => helpers.callAsync((done) => client.quit(done)))
-      );
+      // TODO: can this command fail?
+      return Promise.all(clients.map((client) => client.quit()));
     };
 
-    const closed = helpers.finallyRejectsWithInitial(
+    this._closed = helpers.finallyRejectsWithInitial(
       helpers.withTimeout(drain(), timeout),
       () => cleanup()
     );
 
-    this._closed = closed;
-
-    if (cb) helpers.asCallback(closed, cb);
-    return closed;
+    return this._closed;
   }
 
-  destroy(cb) {
-    const promise = this._commandable().then((client) => {
-      const deleted = helpers.deferred();
-      const args = [
-        'id',
-        'jobs',
-        'stallBlock',
-        'stalling',
-        'waiting',
-        'active',
-        'succeeded',
-        'failed',
-        'delayed',
-      ].map((key) => this.toKey(key));
-      args.push(deleted.defer());
-      client.del.apply(client, args);
-      return deleted;
-    });
-
-    if (cb) helpers.asCallback(promise, cb);
-    return promise;
+  async destroy() {
+    const client = await this._commandable();
+    const args = [
+      'id',
+      'jobs',
+      'waiting',
+      'active',
+      'succeeded',
+      'failed',
+      'delayed',
+      'stallBlock',
+      'stalling',
+    ].map((key) => this.toKey(key));
+    return client.del(args);
   }
 
-  checkHealth(cb) {
-    const promise = this._commandable()
-      .then((client) =>
-        helpers.callAsync((done) =>
-          client
-            .multi()
-            .llen(this.toKey('waiting'))
-            .llen(this.toKey('active'))
-            .scard(this.toKey('succeeded'))
-            .scard(this.toKey('failed'))
-            .zcard(this.toKey('delayed'))
-            .get(this.toKey('id'))
-            .exec(done)
-        )
-      )
-      .then((results) => ({
-        waiting: results[0],
-        active: results[1],
-        succeeded: results[2],
-        failed: results[3],
-        delayed: results[4],
-        newestJob: results[5] ? parseInt(results[5], 10) : 0,
-      }));
-
-    if (cb) helpers.asCallback(promise, cb);
-    return promise;
+  async checkHealth() {
+    const client = await this._commandable();
+    const [
+      [, waiting],
+      [, active],
+      [, succeeded],
+      [, failed],
+      [, delayed],
+      [, newestJob],
+    ] = await client
+      .multi()
+      .llen(this.toKey('waiting'))
+      .llen(this.toKey('active'))
+      .scard(this.toKey('succeeded'))
+      .scard(this.toKey('failed'))
+      .zcard(this.toKey('delayed'))
+      .get(this.toKey('id'))
+      .exec();
+    return {
+      waiting,
+      active,
+      succeeded,
+      failed,
+      delayed,
+      newestJob: newestJob ? parseInt(newestJob, 10) : 0,
+    };
   }
 
-  _scanForJobs(key, cursor, size, set, cb) {
+  async _scanForJobs(key, cursor, size, set) {
     const batchCount = Math.min(size, this.settings.redisScanCount);
-    this.client.sscan(key, cursor, 'COUNT', batchCount, (err, results) => {
-      /* istanbul ignore if */
-      if (err) {
-        return cb(err);
-      }
+    const results = await this.client.sscan(key, cursor, 'COUNT', batchCount);
+    const nextCursor = results[0];
+    const ids = results[1];
 
-      const nextCursor = results[0];
-      const ids = results[1];
+    // A given element may be returned multiple times in SSCAN.
+    // So, we use a set to remove duplicates.
+    // https://redis.io/commands/scan#scan-guarantees
+    for (const id of ids) {
+      // For small sets, encoded as intsets, SSCAN will ignore COUNT.
+      // https://redis.io/commands/scan#the-count-option
+      if (set.size === size) break;
 
-      // A given element may be returned multiple times in SSCAN.
-      // So, we use a set to remove duplicates.
-      // https://redis.io/commands/scan#scan-guarantees
-      for (const id of ids) {
-        // For small sets, encoded as intsets, SSCAN will ignore COUNT.
-        // https://redis.io/commands/scan#the-count-option
-        if (set.size === size) break;
+      set.add(id);
+    }
 
-        set.add(id);
-      }
+    if (nextCursor === '0' || set.size >= size) {
+      return set;
+    }
 
-      if (nextCursor === '0' || set.size >= size) {
-        return cb(null, set);
-      }
-
-      this._scanForJobs(key, nextCursor, size, set, cb);
-    });
+    return this._scanForJobs(key, nextCursor, size, set);
   }
 
-  _addJobsByIds(jobs, ids) {
+  async _addJobsByIds(jobs, ids) {
     // We need to re-ensure the queue is commandable, as we might be shutting
     // down during this operation.
-    return this._commandable()
-      .then((client) => {
-        const got = helpers.deferred();
-        const commandArgs = [this.toKey('jobs')].concat(ids, got.defer());
-        client.hmget.apply(client, commandArgs);
-        return got;
-      })
-      .then((dataArray) => {
-        const count = ids.length;
-        // Some jobs returned by the scan may have already been removed, so
-        // filter them out.
-        for (let i = 0; i < count; ++i) {
-          const jobData = dataArray[i];
-          /* istanbul ignore else: not worth unit-testing this edge case */
-          if (jobData) {
-            jobs.push(Job.fromData(this, ids[i], jobData));
-          }
-        }
-        return jobs;
-      });
+    const client = await this._commandable();
+    const dataArray = await client.hmget([this.toKey('jobs'), ...ids]);
+    // Some jobs returned by the scan may have already been removed, so filter
+    // them out.
+    for (let i = 0; i < ids.length; ++i) {
+      const jobData = dataArray[i];
+      /* istanbul ignore else: not worth unit-testing this edge case */
+      if (jobData) {
+        jobs.push(Job.fromData(this, ids[i], jobData));
+      }
+    }
+    return jobs;
   }
 
   /**
@@ -375,11 +329,7 @@ class Queue extends Emitter {
    *   promise.
    * @return {Promise<Job[]>} Resolves to the jobs the function found.
    */
-  getJobs(type, page, cb) {
-    if (typeof page === 'function') {
-      cb = page;
-      page = null;
-    }
+  async getJobs(type, page) {
     // Set defaults.
     page = Object.assign(
       {
@@ -389,174 +339,167 @@ class Queue extends Emitter {
       },
       page
     );
-    const promise = this._commandable()
-      .then((client) => {
-        const idsPromise = helpers.deferred(),
-          next = idsPromise.defer();
-        const key = this.toKey(type);
-        switch (type) {
-          case 'failed':
-          case 'succeeded':
-            this._scanForJobs(key, '0', page.size, new Set(), next);
-            break;
-          case 'waiting':
-          case 'active':
-            client.lrange(key, page.start, page.end, next);
-            break;
-          case 'delayed':
-            client.zrange(key, page.start, page.end, next);
-            break;
-          default:
-            throw new Error('Improper queue type');
-        }
+    const client = await this._commandable();
 
-        return idsPromise;
-      })
-      .then((ids) => {
-        const jobs = [],
-          idsToFetch = [];
-        // ids might be a Set or an Array, but this will iterate just the same.
-        for (const jobId of ids) {
-          const job = this.jobs.get(jobId);
-          if (job) {
-            jobs.push(job);
-          } else {
-            idsToFetch.push(jobId);
-          }
-        }
-        if (!idsToFetch.length) {
-          return jobs;
-        }
-        return this._addJobsByIds(jobs, idsToFetch);
-      });
+    let ids;
+    const key = this.toKey(type);
+    switch (type) {
+      case 'failed':
+      case 'succeeded':
+        ids = await this._scanForJobs(key, '0', page.size, new Set());
+        break;
+      case 'waiting':
+      case 'active':
+        ids = await client.lrange(key, page.start, page.end);
+        break;
+      case 'delayed':
+        ids = await client.zrange(key, page.start, page.end);
+        break;
+      default:
+        throw new Error('Improper queue type');
+    }
 
-    if (cb) helpers.asCallback(promise, cb);
-    return promise;
+    const jobs = [],
+      idsToFetch = [];
+    // ids might be a Set or an Array, but this will iterate just the same.
+    for (const jobId of ids) {
+      const job = this.jobs.get(jobId);
+      if (job) {
+        jobs.push(job);
+      } else {
+        idsToFetch.push(jobId);
+      }
+    }
+    if (!idsToFetch.length) {
+      return jobs;
+    }
+    return this._addJobsByIds(jobs, idsToFetch);
   }
 
   createJob(data) {
     return new Job(this, null, data);
   }
 
-  getJob(jobId, cb) {
-    const promise = this._commandable()
-      .then(() =>
-        this.jobs.has(jobId) ? this.jobs.get(jobId) : Job.fromId(this, jobId)
-      )
-      .then((job) => {
-        if (job && this.settings.storeJobs) {
-          this.jobs.set(jobId, job);
-        }
-        return job;
-      });
+  async getJob(jobId) {
+    const job = this.jobs.has(jobId)
+      ? this.jobs.get(jobId)
+      : await Job.fromId(this, jobId);
 
-    if (cb) helpers.asCallback(promise, cb);
-    return promise;
+    if (job && this.settings.storeJobs) {
+      this.jobs.set(jobId, job);
+    }
+    return job;
   }
 
-  removeJob(jobId, cb) {
-    const promise = this._evalScript(
+  async removeJob(jobId) {
+    await this._evalScript(
       'removeJob',
       7,
-      this.toKey('succeeded'),
-      this.toKey('failed'),
+      this.toKey('jobs'),
       this.toKey('waiting'),
       this.toKey('active'),
-      this.toKey('stalling'),
-      this.toKey('jobs'),
+      this.toKey('succeeded'),
+      this.toKey('failed'),
       this.toKey('delayed'),
+      this.toKey('stalling'),
       jobId
-    ).then(() => {
-      if (this.settings.storeJobs) {
-        this.jobs.delete(jobId);
-      }
-      return this;
-    });
+    );
 
-    if (cb) helpers.asCallback(promise, cb);
-    return promise;
+    if (this.settings.storeJobs) {
+      this.jobs.delete(jobId);
+    }
+    return this;
   }
 
-  _waitForJob() {
-    return helpers
-      .callAsync((done) =>
-        this.bclient.brpoplpush(
-          this.toKey('waiting'),
-          this.toKey('active'),
-          0,
-          done
-        )
-      )
-      .then(
-        (jobId) =>
-          // Note that the job may be null in the case that the client has
-          // removed the job before processing can take place, but after the
-          // brpoplpush has returned the job id.
-          Job.fromId(this, jobId),
-        (err) =>
-          redis.isAbortError(err) && this.paused ? null : Promise.reject(err)
+  async _waitForJob() {
+    let jobId;
+    try {
+      jobId = await this.bclient.brpoplpush(
+        this.toKey('waiting'),
+        this.toKey('active'),
+        0
       );
+    } catch (err) {
+      if (redis.isAbortError(err) && this.paused) {
+        return null;
+      }
+      throw err;
+    }
+    // Note that the job may be null in the case that the client has removed
+    // the job before processing can take place, but after the brpoplpush has
+    // returned the job id.
+    return Job.fromId(this, jobId);
   }
 
-  _getNextJob() {
+  async _getNextJob() {
     // Under normal calling conditions, commandable will not reject because we
     // will have just checked paused in Queue#process.
-    return this._commandable(true).then(() => this._waitForJob());
+    await this._commandable(true);
+    return this._waitForJob();
   }
 
-  _runJob(job) {
+  async _runJob(job) {
     let psTimeout = null,
       completed = false;
 
-    const preventStalling = () => {
+    const preventStalling = async () => {
       psTimeout = null;
       if (this._isClosed) return;
-      finally_(this._preventStall(job.id), () => {
-        if (completed || this._isClosed) return;
-        const interval = this.settings.stallInterval / 2;
-        psTimeout = setTimeout(preventStalling, interval);
-      }).catch(this._emitErrorAfterTick);
+      await this._preventStall(job.id);
+      if (completed || this._isClosed) return;
+      const interval = this.settings.stallInterval / 2;
+      psTimeout = setTimeout(preventStalling, interval);
     };
     preventStalling();
 
-    const handleOutcome = (err, data) => {
+    let handlerPromise = Promise.resolve(this.handler(job));
+    // todo maybe check for this thing being promise-y for helpful error message
+
+    if (job.options.timeout) {
+      const message = `Job ${job.id} timed out (${job.options.timeout} ms)`;
+      handlerPromise = helpers.withTimeout(
+        handlerPromise,
+        job.options.timeout,
+        message
+      );
+    }
+
+    const evaluateJob = async (promise) => {
+      let successData, failureErr;
+      try {
+        successData = await promise;
+      } catch (err) {
+        failureErr = err || new Error('unspecified job error');
+      }
       completed = true;
       if (psTimeout) {
         clearTimeout(psTimeout);
         psTimeout = null;
       }
-
-      return this._finishJob(err, data, job);
+      // The only error that can happen here is either network- or
+      // Redis-related, or if Queue#close times out while a job is
+      // processing, and the job later finishes.
+      // In those cases, throwing to reject is what we want.
+      return this._finishJob(failureErr, successData, job);
     };
 
-    let promise = this.handler(job);
-
-    if (job.options.timeout) {
-      const message = `Job ${job.id} timed out (${job.options.timeout} ms)`;
-      promise = helpers.withTimeout(promise, job.options.timeout, message);
-    }
-
-    const jobPromise = finally_(
-      promise.then((data) => handleOutcome(null, data), handleOutcome),
-      // The only error that can happen here is either network- or
-      // Redis-related, or if Queue#close times out while a job is processing,
-      // and the job later finishes.
-      () => this.activeJobs.delete(jobPromise)
+    // We specifically use the value produced by the async to avoid cases where
+    // the process handler returns the same Promise object each invocation.
+    const jobPromise = evaluateJob(handlerPromise).finally(() =>
+      this.activeJobs.delete(jobPromise)
     );
-
-    // We specifically use the value produced by then to avoid cases where the
-    // process handler returns the same Promise object each invocation.
     this.activeJobs.add(jobPromise);
     return jobPromise;
   }
 
   _preventStall(jobId) {
-    return helpers.callAsync((done) =>
-      this.client.srem(this.toKey('stalling'), jobId, done)
-    );
+    // todo figure out coverage/refactor here
+    const promise = this.client.srem(this.toKey('stalling'), jobId);
+    /* istanbul ignore next: these errors are only redis or network errors */
+    return promise.catch(this._emitErrorAfterTick);
   }
 
-  _finishJob(err, data, job) {
+  async _finishJob(err, data, job) {
     const status = err ? 'failed' : 'succeeded';
 
     if (this._isClosed) {
@@ -624,9 +567,9 @@ class Queue extends Emitter {
 
     const result = err || data;
 
-    return helpers
-      .callAsync((done) => multi.exec(done))
-      .then(() => [status, result]);
+    await multi.exec();
+
+    return [status, result];
   }
 
   process(concurrency, handler) {
@@ -647,10 +590,8 @@ class Queue extends Emitter {
       concurrency = defaults['#process'].concurrency;
     }
 
-    // If the handler throws a synchronous exception (only applicable to
-    // non-`async` functions), catch it, and fail the job.
-    const catchExceptions = true;
-    this.handler = helpers.wrapAsync(handler, catchExceptions);
+    // handler now *must* return a promise - no more callback calling
+    this.handler = handler;
     this.running = 0;
     this.queued = 1;
     this.concurrency = concurrency;
@@ -663,8 +604,8 @@ class Queue extends Emitter {
 
       // invariant: in this code path, this.running < this.concurrency, always
       // after spoolup, this.running + this.queued === this.concurrency
-      finally_(
-        this._getNextJob().then((job) => {
+      this._getNextJob()
+        .then((job) => {
           // We're shutting down.
           if (this.paused) {
             // This job will get picked up later as a stalled job if we happen
@@ -701,9 +642,9 @@ class Queue extends Emitter {
               this.emit(status, job, result);
             }
           }, this._emitErrorAfterTick);
-        }),
-        () => setImmediate(jobTick)
-      ).catch(this._emitErrorAfterTick);
+        })
+        .finally(() => setImmediate(jobTick))
+        .catch(this._emitErrorAfterTick);
     };
 
     this._doStalledJobCheck().then(jobTick).catch(this._emitErrorAfterTick);
@@ -749,9 +690,17 @@ class Queue extends Emitter {
 
   _checkStalledJobs(interval, cb) {
     const promise = this._doStalledJobCheck();
-    if (cb) helpers.asCallback(promise, cb);
+    // TODO: what DO
+    // TODO: reintroduce tests
+    if (cb) {
+      promise.then(
+        (value) => process.nextTick(() => cb(null, value)),
+        (err) => process.nextTick(() => cb(err))
+      );
+    }
+    //if (cb) helpers.asCallback(promise, cb);
     return interval && !this.checkTimer
-      ? finally_(promise, () => {
+      ? promise.finally(() => {
           try {
             this._scheduleStalledCheck(interval, cb);
           } catch (err) {
@@ -798,22 +747,38 @@ class Queue extends Emitter {
    *   exception executing the batch or readying the connection.
    * @modifies {arguments}
    */
-  saveAll(jobs) {
-    return this._commandable().then((client) => {
-      const batch = client.batch(),
-        errors = new Map();
+  async saveAll(jobs) {
+    const client = await this._commandable();
+    const batch = client.pipeline(),
+      errors = new Map(),
+      defers = [];
 
-      for (const job of jobs) {
-        try {
-          job
-            ._save((evalArgs) => this._evalScriptOn(batch, evalArgs))
-            .catch((err) => void errors.set(job, err));
-        } catch (err) {
-          errors.set(job, err);
-        }
+    const final = Promise.all(
+      jobs.map((job) => {
+        const defer = helpers.defer();
+        return job
+          ._save((evalArgs) => {
+            this._evalScriptOn(batch, evalArgs);
+            defers.push(defer);
+            return defer.promise;
+          })
+          .catch((err) => {
+            // Catch both errors from defer.reject below (from the EVALSHA), and
+            // from any serialization failures.
+            errors.set(job, err);
+          });
+      })
+    );
+    const results = await batch.exec();
+    for (const [defer, [error, jobId]] of helpers.zip(defers, results)) {
+      if (error) {
+        defer.reject(error);
+      } else {
+        defer.resolve(jobId);
       }
-      return helpers.callAsync((done) => batch.exec(done)).then(() => errors);
-    });
+    }
+    await final;
+    return errors;
   }
 
   _activateDelayed() {
@@ -860,10 +825,7 @@ class Queue extends Emitter {
   _evalScriptOn(commandable, args) {
     // Precondition: Queue is ready - otherwise lua.shas may not have loaded.
     args[0] = lua.shas[args[0]];
-    return helpers.callAsync((done) => {
-      args.push(done);
-      commandable.evalsha.apply(commandable, args);
-    });
+    return commandable.evalsha(args);
   }
 
   /**
@@ -873,17 +835,10 @@ class Queue extends Emitter {
    *
    * @param {string} name
    */
-  _evalScript() {
-    // Avoid deoptimization by leaking arguments: store them directly in an
-    // array instead of passing them to a helper.
-    const args = new Array(arguments.length);
-    for (let i = 0; i < arguments.length; ++i) {
-      args[i] = arguments[i];
-    }
-
-    return this._commandable().then((client) =>
-      this._evalScriptOn(client, args)
-    );
+  async _evalScript(...args) {
+    // Get the sha for the script after we're ready to avoid a race condition
+    // with the lua script loader.
+    return this._evalScriptOn(await this._commandable(), args);
   }
 }
 

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -6,10 +6,28 @@ const helpers = require('./helpers');
 // todo utilize ioredis [options.keyPrefix]
 // todo maybe utilize ioredis redis.defineCommand for lua scripts
 
-async function createClient(settings, createNew) {
-  let client;
-  // TODO: separately support node_redis client conversion?
-  if (isClient(settings)) {
+const clientIDs = new WeakMap();
+
+class AbortError extends Error {
+  constructor() {
+    super('Connection is closed.');
+    this.name = this.constructor.name;
+  }
+}
+
+async function createClient(
+  settings,
+  { createNew = false, getClientID = false } = {}
+) {
+  let client,
+    isNewClient = true;
+  const clientType = getClientType(settings);
+  if (clientType === 'NodeRedis') {
+    throw new TypeError(
+      "clients produced by the NodeRedis library ('redis' on npm) are no longer supported as of bee-queue@2"
+    );
+  }
+  if (clientType) {
     // We've actually been passed an existing client instance
     client = settings;
 
@@ -20,10 +38,20 @@ async function createClient(settings, createNew) {
       // enable connection sharing between Queue instances), and it's already
       // ready, then just return it.
       return client;
-    } // TODO: otherwise, don't disconnect!!
+    } else {
+      isNewClient = false;
+    }
   } else {
-    // todo ensure ioredis does not mutate the options object we provide it
     client = Redis.createClient(settings);
+  }
+
+  if (getClientID && isNewClient) {
+    // Best-effort attempt to get the client ID. Might fail due to connection
+    // errors or due to an incompatible redis version.
+    client.client('ID').then(
+      (id) => clientIDs.set(client, id),
+      () => {}
+    );
   }
 
   // Make sure the client is "ready" (connected etc) before we return it
@@ -33,43 +61,75 @@ async function createClient(settings, createNew) {
     // If we receive an error before the client becomes ready, we won't retain a
     // reference to it, so we should disconnect the client to prevent uncaught
     // exceptions.
-    disconnect(client);
+    if (isNewClient) {
+      disconnect(client);
+    }
     throw err;
   }
   return client;
 }
 
+async function cleanDisconnect(client, commandClient) {
+  if (!clientIDs.has(client)) {
+    // Disable auto-reconnection.
+    client.options.retryStrategy = false;
+    try {
+      await commandClient.client(
+        'KILL',
+        'ID',
+        String(clientIDs.get(client)),
+        'SKIPME',
+        'no'
+      );
+      await helpers.waitOn(client, 'end', true);
+      clientIDs.delete(client);
+      return;
+    } catch (err) {
+      // Fallthrough.
+    }
+  }
+  disconnect(client);
+}
+
 function disconnect(client) {
+  // HACK: flushQueue is, according to ioredis, private. This is unfortunate,
+  // because we need this in order to properly clean up during brpoplpush
+  // commands.
+  client.flushQueue(new AbortError());
   client.disconnect();
-  // todo ensure pending promises/actions abort correctly
-  // } else {
-  //   true indicates that it should invoke all pending callbacks with an
-  //   AbortError; we need this behavior.
-  //   client.end(true);
-  // }
 }
 
 function isAbortError(err) {
   // Checking for a particular constant message defined in ioredis's utils
   // TODO: can we use some other field?
-  return err.message === 'Connection is closed.';
+  return err.name === 'AbortError' || err.message === 'Connection is closed.';
 }
 
-function isClient(object) {
-  if (!object || typeof object !== 'object') return false;
+const rBoundary = /\b/g;
+function errorCode(err) {
+  rBoundary.lastIndex = 1;
+  const { message } = err,
+    match = rBoundary.exec(err.message);
+  return err.message.slice(0, match ? match.index : undefined);
+}
+
+function getClientType(object) {
+  if (!object || typeof object !== 'object') return null;
   const name = object.constructor.name;
-  // todo make sure this is right name for ioredis
-  // TODO: this would be name == 'RedisClient' for node_redis, possibly.
-  return name === 'Redis';
+  if (name === 'Redis') return 'ioredis';
+  if (name === 'RedisClient') return 'NodeRedis';
+  return null;
 }
 
 function isReady(client) {
-  // TODO: this would be client.ready as a bool if we coerce the node_redis client
-  return client.status === 'ready';
+  // HACK: manuallyClosing is, according to ioredis, private. This is necessary
+  // to work around https://github.com/luin/ioredis/issues/614.
+  return client.status === 'ready' && !client.manuallyClosing;
 }
 
 exports.createClient = createClient;
+exports.cleanDisconnect = cleanDisconnect;
 exports.disconnect = disconnect;
 exports.isAbortError = isAbortError;
-exports.isClient = isClient;
+exports.isClient = (object) => getClientType(object) === 'ioredis';
 exports.isReady = isReady;

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -1,75 +1,71 @@
 'use strict';
 
-const redis = require('redis');
+const Redis = require('ioredis');
 const helpers = require('./helpers');
 
-function createClient(settings, createNew) {
+// todo utilize ioredis [options.keyPrefix]
+// todo maybe utilize ioredis redis.defineCommand for lua scripts
+
+async function createClient(settings, createNew) {
   let client;
+  // TODO: separately support node_redis client conversion?
   if (isClient(settings)) {
-    // We assume it's a redis client from either node_redis or ioredis.
+    // We've actually been passed an existing client instance
     client = settings;
 
     if (createNew) {
-      // Both node_redis and ioredis support the duplicate method, which creates
-      // a new redis client with the same configuration.
       client = client.duplicate();
     } else if (isReady(client)) {
       // If we were given a redis client, and we don't want to clone it (to
       // enable connection sharing between Queue instances), and it's already
       // ready, then just return it.
-      return Promise.resolve(client);
-    } // otherwise, we wait for the client to be in the ready state.
+      return client;
+    } // TODO: otherwise, don't disconnect!!
   } else {
-    // node_redis mutates the options object we provide it, so we clone the
-    // settings first.
-    if (typeof settings === 'object') {
-      settings = Object.assign({}, settings);
-    }
-
-    client = redis.createClient(settings);
+    // todo ensure ioredis does not mutate the options object we provide it
+    client = Redis.createClient(settings);
   }
 
-  // Wait for the client to be ready, then resolve with the client itself.
-  return helpers.waitOn(client, 'ready', true).then(
-    () => client,
+  // Make sure the client is "ready" (connected etc) before we return it
+  try {
+    await helpers.waitOn(client, 'ready', true);
+  } catch (err) {
     // If we receive an error before the client becomes ready, we won't retain a
     // reference to it, so we should disconnect the client to prevent uncaught
     // exceptions.
-    (err) => (disconnect(client), Promise.reject(err))
-  );
+    disconnect(client);
+    throw err;
+  }
+  return client;
 }
 
 function disconnect(client) {
-  // Redis#end is deprecated for ioredis.
-  /* istanbul ignore if: this is only for ioredis */
-  if (client.disconnect) {
-    client.disconnect();
-  } else {
-    // true indicates that it should invoke all pending callbacks with an
-    // AbortError; we need this behavior.
-    client.end(true);
-  }
+  client.disconnect();
+  // todo ensure pending promises/actions abort correctly
+  // } else {
+  //   true indicates that it should invoke all pending callbacks with an
+  //   AbortError; we need this behavior.
+  //   client.end(true);
+  // }
 }
 
 function isAbortError(err) {
-  // node_redis has a designated class for abort errors, but ioredis just has
-  // a constant message defined in a utils file.
-  return (
-    err.name === 'AbortError' ||
-    /* istanbul ignore next: this is only for ioredis */
-    err.message === 'Connection is closed.'
-  );
+  // Checking for a particular constant message defined in ioredis's utils
+  // TODO: can we use some other field?
+  return err.message === 'Connection is closed.';
 }
 
 function isClient(object) {
   if (!object || typeof object !== 'object') return false;
   const name = object.constructor.name;
-  return name === 'Redis' || name === 'RedisClient';
+  // todo make sure this is right name for ioredis
+  // TODO: this would be name == 'RedisClient' for node_redis, possibly.
+  return name === 'Redis';
 }
 
 function isReady(client) {
-  // node_redis has a ready property, ioredis has a status property.
-  return client.ready || client.status === 'ready';
+  // TODO: this would be client.ready as a bool if we coerce the node_redis client
+  return client.status === 'ready';
 }
 
 exports.createClient = createClient;

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -19,6 +19,10 @@ async function createClient(
   settings,
   { createNew = false, getClientID = false } = {}
 ) {
+  if (getClientID && !createNew) {
+    throw new Error('cannot track client ID reliably for existing clients');
+  }
+
   let client,
     isNewClient = true;
   const clientType = getClientType(settings);
@@ -32,7 +36,7 @@ async function createClient(
     client = settings;
 
     if (createNew) {
-      client = client.duplicate();
+      client = client.duplicate({ autoResendUnfulfilledCommands: false });
     } else if (isReady(client)) {
       // If we were given a redis client, and we don't want to clone it (to
       // enable connection sharing between Queue instances), and it's already
@@ -42,16 +46,26 @@ async function createClient(
       isNewClient = false;
     }
   } else {
-    client = Redis.createClient(settings);
+    client = Redis.createClient(
+      getClientID
+        ? { ...settings, autoResendUnfulfilledCommands: false }
+        : settings
+    );
   }
 
   if (getClientID && isNewClient) {
-    // Best-effort attempt to get the client ID. Might fail due to connection
-    // errors or due to an incompatible redis version.
-    client.client('ID').then(
-      (id) => clientIDs.set(client, id),
-      () => {}
-    );
+    function refreshClientID() {
+      // Best-effort attempt to get the client ID. Might fail due to connection
+      // errors or due to an incompatible redis version.
+      client.client('ID').then(
+        (id) => clientIDs.set(client, id),
+        () => {}
+      );
+    }
+
+    client.on('reconnecting', refreshClientID);
+    client.on('close', () => clientIDs.delete(client));
+    refreshClientID();
   }
 
   // Make sure the client is "ready" (connected etc) before we return it
@@ -70,7 +84,7 @@ async function createClient(
 }
 
 async function cleanDisconnect(client, commandClient) {
-  if (!clientIDs.has(client)) {
+  if (clientIDs.has(client)) {
     // Disable auto-reconnection.
     client.options.retryStrategy = false;
     try {
@@ -130,6 +144,7 @@ function isReady(client) {
 exports.createClient = createClient;
 exports.cleanDisconnect = cleanDisconnect;
 exports.disconnect = disconnect;
+exports.errorCode = errorCode;
 exports.isAbortError = isAbortError;
 exports.isClient = (object) => getClientType(object) === 'ioredis';
 exports.isReady = isReady;

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -88,14 +88,16 @@ async function cleanDisconnect(client, commandClient) {
     // Disable auto-reconnection.
     client.options.retryStrategy = false;
     try {
-      await commandClient.client(
-        'KILL',
-        'ID',
-        String(clientIDs.get(client)),
-        'SKIPME',
-        'no'
-      );
-      await helpers.waitOn(client, 'end', true);
+      await Promise.all([
+        helpers.waitOn(client, 'end', true),
+        commandClient.client(
+          'KILL',
+          'ID',
+          String(clientIDs.get(client)),
+          'SKIPME',
+          'no'
+        ),
+      ]);
       clientIDs.delete(client);
       return;
     } catch (err) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -335,6 +335,7 @@
       "version": "7.11.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
       "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -342,7 +343,8 @@
         "regenerator-runtime": {
           "version": "0.13.7",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+          "dev": true
         }
       }
     },
@@ -3081,8 +3083,7 @@
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "dev": true
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "bottleneck": {
       "version": "2.19.5",
@@ -3201,6 +3202,24 @@
             "imurmurhash": "^0.1.4",
             "slide": "^1.1.5"
           }
+        }
+      }
+    },
+    "call-bind": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
+      "integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.0"
+      },
+      "dependencies": {
+        "function-bind": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+          "dev": true
         }
       }
     },
@@ -3419,6 +3438,11 @@
           }
         }
       }
+    },
+    "cluster-key-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
+      "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw=="
     },
     "co-with-promise": {
       "version": "4.6.0",
@@ -4277,6 +4301,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true,
       "requires": {
         "foreach": "^2.0.5",
         "object-keys": "^1.0.8"
@@ -4335,6 +4360,11 @@
         }
       }
     },
+    "denque": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
+      "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
+    },
     "deprecation": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
@@ -4390,11 +4420,6 @@
       "requires": {
         "is-obj": "^1.0.0"
       }
-    },
-    "double-ended-queue": {
-      "version": "2.1.0-0",
-      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
-      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
     },
     "duplexer2": {
       "version": "0.1.4",
@@ -4570,32 +4595,44 @@
       }
     },
     "es-abstract": {
-      "version": "1.17.6",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-      "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+      "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+      "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.2.0",
-        "is-regex": "^1.1.0",
-        "object-inspect": "^1.7.0",
+        "is-callable": "^1.2.2",
+        "is-regex": "^1.1.1",
+        "object-inspect": "^1.8.0",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.0",
+        "object.assign": "^4.1.1",
         "string.prototype.trimend": "^1.0.1",
         "string.prototype.trimstart": "^1.0.1"
       },
       "dependencies": {
+        "define-properties": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+          "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+          "dev": true,
+          "requires": {
+            "object-keys": "^1.0.12"
+          }
+        },
         "function-bind": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+          "dev": true
         },
         "has": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
           "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "dev": true,
           "requires": {
             "function-bind": "^1.1.1"
           }
@@ -4604,14 +4641,34 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
           "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+          "dev": true,
           "requires": {
             "has-symbols": "^1.0.1"
           }
         },
+        "object-inspect": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+          "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
+          "dev": true
+        },
         "object-keys": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
+        },
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
         }
       }
     },
@@ -4619,6 +4676,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -5257,6 +5315,11 @@
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
     },
+    "flexbuffer": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/flexbuffer/-/flexbuffer-0.0.6.tgz",
+      "integrity": "sha1-A5/fI/iCPkQMOPMnfm/vEXQhWzA="
+    },
     "fn-name": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
@@ -5281,7 +5344,8 @@
     "foreach": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
     },
     "foreground-child": {
       "version": "2.0.0",
@@ -5949,6 +6013,34 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
+    "get-intrinsic": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
+      "integrity": "sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      },
+      "dependencies": {
+        "function-bind": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+          "dev": true
+        },
+        "has": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        }
+      }
+    },
     "get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -6393,7 +6485,8 @@
     "has-symbols": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "dev": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -6694,6 +6787,51 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "ioredis": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-3.2.2.tgz",
+      "integrity": "sha512-g+ShTQYLsCcOUkNOK6CCEZbj3aRDVPw3WOwXk+LxlUKvuS9ujEqP2MppBHyRVYrNNFW/vcPaTBUZ2ctGNSiOCA==",
+      "requires": {
+        "bluebird": "^3.3.4",
+        "cluster-key-slot": "^1.0.6",
+        "debug": "^2.6.9",
+        "denque": "^1.1.0",
+        "flexbuffer": "0.0.6",
+        "lodash.assign": "^4.2.0",
+        "lodash.bind": "^4.2.1",
+        "lodash.clone": "^4.5.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.foreach": "^4.5.0",
+        "lodash.isempty": "^4.4.0",
+        "lodash.keys": "^4.2.0",
+        "lodash.noop": "^3.0.1",
+        "lodash.partial": "^4.2.1",
+        "lodash.pick": "^4.4.0",
+        "lodash.sample": "^4.2.1",
+        "lodash.shuffle": "^4.2.0",
+        "lodash.values": "^4.3.0",
+        "redis-commands": "^1.2.0",
+        "redis-parser": "^2.4.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "irregular-plurals": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
@@ -6737,9 +6875,10 @@
       "dev": true
     },
     "is-callable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+      "dev": true
     },
     "is-ci": {
       "version": "1.2.1",
@@ -6762,7 +6901,8 @@
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -6964,6 +7104,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
       }
@@ -7402,17 +7543,31 @@
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
     },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+    },
+    "lodash.bind": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
+      "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU="
+    },
     "lodash.capitalize": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
       "integrity": "sha1-+CbJtOKoUR2E46yinbBeGk87cqk=",
       "dev": true
     },
+    "lodash.clone": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+      "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
+    },
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "dev": true
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.clonedeepwith": {
       "version": "4.5.0",
@@ -7426,11 +7581,15 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+    },
     "lodash.difference": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
-      "dev": true
+      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
     },
     "lodash.escaperegexp": {
       "version": "4.1.2",
@@ -7441,14 +7600,23 @@
     "lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
-      "dev": true
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
+    },
+    "lodash.foreach": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+      "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
+    },
+    "lodash.isempty": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
     },
     "lodash.isequal": {
       "version": "4.5.0",
@@ -7474,11 +7642,41 @@
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
       "dev": true
     },
+    "lodash.keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
+      "integrity": "sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU="
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "lodash.noop": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-3.0.1.tgz",
+      "integrity": "sha1-OBiPTWUKOkdCWEObluxFsyYXEzw="
+    },
+    "lodash.partial": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.partial/-/lodash.partial-4.2.1.tgz",
+      "integrity": "sha1-SfPYz9qjv/izqR0SfpIyRUGJYdQ="
+    },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
+    },
+    "lodash.sample": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.sample/-/lodash.sample-4.2.1.tgz",
+      "integrity": "sha1-XkKRsMdT+hq+sKq4+ynfG2bwf20="
+    },
+    "lodash.shuffle": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.shuffle/-/lodash.shuffle-4.2.0.tgz",
+      "integrity": "sha1-FFtQU8+HX29cKjP0i26ZSMbse0s="
     },
     "lodash.template": {
       "version": "4.5.0",
@@ -7510,6 +7708,11 @@
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
       "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
       "dev": true
+    },
+    "lodash.values": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-4.3.0.tgz",
+      "integrity": "sha1-o6bCsOvsxcLLocF+bmIP6BtT00c="
     },
     "lolex": {
       "version": "6.0.0",
@@ -11850,7 +12053,8 @@
     "object-inspect": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "dev": true
     },
     "object-is": {
       "version": "1.0.2",
@@ -11861,7 +12065,8 @@
     "object-keys": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
@@ -11884,6 +12089,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "function-bind": "^1.1.1",
@@ -11894,7 +12100,8 @@
         "function-bind": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+          "dev": true
         }
       }
     },
@@ -11902,6 +12109,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
       "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
@@ -11911,6 +12119,7 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
           "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+          "dev": true,
           "requires": {
             "object-keys": "^1.0.12"
           }
@@ -11918,7 +12127,8 @@
         "object-keys": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
         }
       }
     },
@@ -12064,7 +12274,8 @@
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
     },
     "p-is-promise": {
       "version": "3.0.0",
@@ -12423,6 +12634,7 @@
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/promise-callbacks/-/promise-callbacks-3.8.2.tgz",
       "integrity": "sha512-g+SziwZr9eLwF+Tejuz0nirmzrYm1Ou4dExaRap1+wG/Bip1FAjMwE+oOqwv6C+CxDCQJ9l0jMSE8ui1oRC/tQ==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.9.2",
         "object.getownpropertydescriptors": "2.1.0"
@@ -12877,20 +13089,10 @@
         "esprima": "~4.0.0"
       }
     },
-    "redis": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
-      "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
-      "requires": {
-        "double-ended-queue": "^2.1.0-0",
-        "redis-commands": "^1.2.0",
-        "redis-parser": "^2.6.0"
-      }
-    },
     "redis-commands": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz",
-      "integrity": "sha1-gdgm9F+pyLIBH0zXoP5ZfSQdRCs="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.6.0.tgz",
+      "integrity": "sha512-2jnZ0IkjZxvguITjFTrGiLyzQZcTvaw8DAaCXxZq/dsHXz7KfMQ3OUJy7Tz9vnRtZRVz6VRCPDvruvU8Ts44wQ=="
     },
     "redis-parser": {
       "version": "2.6.0",
@@ -14140,6 +14342,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
       "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -14149,6 +14352,7 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
           "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+          "dev": true,
           "requires": {
             "object-keys": "^1.0.12"
           }
@@ -14157,6 +14361,7 @@
           "version": "1.17.5",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
           "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+          "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
@@ -14175,6 +14380,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
           "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "dev": true,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -14184,12 +14390,14 @@
         "function-bind": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+          "dev": true
         },
         "has": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
           "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "dev": true,
           "requires": {
             "function-bind": "^1.1.1"
           }
@@ -14197,12 +14405,14 @@
         "is-callable": {
           "version": "1.1.5",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
+          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+          "dev": true
         },
         "is-regex": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
           "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+          "dev": true,
           "requires": {
             "has": "^1.0.3"
           }
@@ -14211,6 +14421,7 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
           "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+          "dev": true,
           "requires": {
             "has-symbols": "^1.0.1"
           }
@@ -14218,7 +14429,8 @@
         "object-keys": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
         }
       }
     },
@@ -14226,6 +14438,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
       "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5",
@@ -14236,6 +14449,7 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
           "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+          "dev": true,
           "requires": {
             "object-keys": "^1.0.12"
           }
@@ -14244,6 +14458,7 @@
           "version": "1.17.5",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
           "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+          "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
@@ -14262,6 +14477,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
           "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "dev": true,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -14271,12 +14487,14 @@
         "function-bind": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+          "dev": true
         },
         "has": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
           "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "dev": true,
           "requires": {
             "function-bind": "^1.1.1"
           }
@@ -14284,12 +14502,14 @@
         "is-callable": {
           "version": "1.1.5",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
+          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+          "dev": true
         },
         "is-regex": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
           "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+          "dev": true,
           "requires": {
             "has": "^1.0.3"
           }
@@ -14298,6 +14518,7 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
           "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+          "dev": true,
           "requires": {
             "has-symbols": "^1.0.1"
           }
@@ -14305,7 +14526,8 @@
         "object-keys": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
         }
       }
     },
@@ -14313,6 +14535,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
       "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5",
@@ -14323,6 +14546,7 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
           "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+          "dev": true,
           "requires": {
             "object-keys": "^1.0.12"
           }
@@ -14331,6 +14555,7 @@
           "version": "1.17.5",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
           "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+          "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
@@ -14349,6 +14574,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
           "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "dev": true,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -14358,12 +14584,14 @@
         "function-bind": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+          "dev": true
         },
         "has": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
           "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "dev": true,
           "requires": {
             "function-bind": "^1.1.1"
           }
@@ -14371,12 +14599,14 @@
         "is-callable": {
           "version": "1.1.5",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
+          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+          "dev": true
         },
         "is-regex": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
           "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+          "dev": true,
           "requires": {
             "has": "^1.0.3"
           }
@@ -14385,6 +14615,7 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
           "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+          "dev": true,
           "requires": {
             "has-symbols": "^1.0.1"
           }
@@ -14392,7 +14623,8 @@
         "object-keys": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
         }
       }
     },
@@ -14400,6 +14632,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
       "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -14409,6 +14642,7 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
           "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+          "dev": true,
           "requires": {
             "object-keys": "^1.0.12"
           }
@@ -14417,6 +14651,7 @@
           "version": "1.17.5",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
           "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+          "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
@@ -14435,6 +14670,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
           "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "dev": true,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -14444,12 +14680,14 @@
         "function-bind": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+          "dev": true
         },
         "has": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
           "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "dev": true,
           "requires": {
             "function-bind": "^1.1.1"
           }
@@ -14457,12 +14695,14 @@
         "is-callable": {
           "version": "1.1.5",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
+          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+          "dev": true
         },
         "is-regex": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
           "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+          "dev": true,
           "requires": {
             "has": "^1.0.3"
           }
@@ -14471,6 +14711,7 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
           "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+          "dev": true,
           "requires": {
             "has-symbols": "^1.0.1"
           }
@@ -14478,7 +14719,8 @@
         "object-keys": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -4,9 +4,7 @@
   "description": "A simple, fast, robust job/task queue, backed by Redis.",
   "main": "index.js",
   "dependencies": {
-    "p-finally": "^1.0.0",
-    "promise-callbacks": "^3.8.1",
-    "redis": "^2.7.1"
+    "ioredis": "^3.2.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",
@@ -27,6 +25,7 @@
     "lolex": "^6.0.0",
     "nyc": "^15.0.1",
     "prettier": "^2.0.4",
+    "promise-callbacks": "^3.8.2",
     "sandboxed-module": "^2.0.3",
     "semantic-release": "^17.2.2",
     "semver": "^7.2.1",
@@ -51,6 +50,11 @@
     "report": "npm run coverage && nyc report --reporter=html",
     "test": "npm run lint && ava"
   },
+  "ava": {
+    "files": [
+      "test/*-test.js"
+    ]
+  },
   "keywords": [
     "task",
     "job",
@@ -62,7 +66,7 @@
     "lua"
   ],
   "engines": {
-    "node": ">= 4"
+    "node": ">= 8"
   },
   "author": "Lewis J Ellis <me@lewisjellis.com>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "lib"
   ],
   "scripts": {
-    "ci": "if node -e '({...0})' 2>/dev/null && node -e '\"\".trimEnd()' 2>/dev/null; then npm run lint && npm run ci:coverage && if [ -z \"$CI\" ]; then npm run ci:commitlint; fi; else ava; fi",
-    "ci:commitlint": "if node -e 'async()=>{for await(var a of a);}'; then commitlint --from \"origin/${GITHUB_BASE_REF:-master}\"; fi",
+    "ci": "npm run lint && npm run ci:coverage && if [ -z \"$CI\" ]; then npm run ci:commitlint; fi; else ava",
+    "ci:commitlint": "commitlint --from \"origin/${GITHUB_BASE_REF:-master}\"",
     "ci:coverage": "if [ -z \"$CI\" ]; then npm run coverage; else npm run coverage-and-report; fi",
     "coverage-and-report": "npm run coverage && mkdir -p coverage && nyc report --reporter=text-lcov > coverage/lcov.info",
     "coverage": "nyc ava",

--- a/release.config.js
+++ b/release.config.js
@@ -1,17 +1,20 @@
 module.exports = {
   plugins: [
-    ['@semantic-release/commit-analyzer', {preset: 'conventionalcommits'}],
+    ['@semantic-release/commit-analyzer', { preset: 'conventionalcommits' }],
     [
       '@semantic-release/release-notes-generator',
-      {preset: 'conventionalcommits'},
+      { preset: 'conventionalcommits' },
     ],
     '@semantic-release/github',
-    ['@semantic-release/changelog', {changelogFile: 'HISTORY.md'}],
-    ['@semantic-release/exec', {prepareCmd: 'npx prettier --write HISTORY.md'}],
+    ['@semantic-release/changelog', { changelogFile: 'HISTORY.md' }],
+    [
+      '@semantic-release/exec',
+      { prepareCmd: 'npx prettier --write HISTORY.md' },
+    ],
     '@semantic-release/npm',
     [
       '@semantic-release/git',
-      {assets: ['HISTORY.md', 'package.json', 'package-lock.json']},
+      { assets: ['HISTORY.md', 'package.json', 'package-lock.json'] },
     ],
   ],
 };

--- a/test/eager-timer-test.js
+++ b/test/eager-timer-test.js
@@ -1,4 +1,4 @@
-import {describe} from 'ava-spec';
+import { describe } from 'ava-spec';
 import sandbox from 'sandboxed-module';
 import lolex from 'lolex';
 import sinon from 'sinon';
@@ -42,11 +42,11 @@ describe('EagerTimer', (it) => {
     const trigger = sinon.spy();
     timer.on('trigger', trigger);
 
-    Object.assign(t.context, {EagerTimer, timer, clock, start, trigger});
+    Object.assign(t.context, { EagerTimer, timer, clock, start, trigger });
   });
 
   it('should trigger in the future', (t) => {
-    const {clock, timer, start, trigger} = t.context;
+    const { clock, timer, start, trigger } = t.context;
 
     timer.schedule(start + 200);
     t.false(trigger.called);
@@ -55,7 +55,7 @@ describe('EagerTimer', (it) => {
   });
 
   it('should not trigger after the maximum delay', (t) => {
-    const {clock, timer, start, trigger} = t.context;
+    const { clock, timer, start, trigger } = t.context;
 
     timer.schedule(start + 600);
     t.false(trigger.called);
@@ -64,7 +64,7 @@ describe('EagerTimer', (it) => {
   });
 
   it('should trigger again', (t) => {
-    const {clock, timer, start, trigger} = t.context;
+    const { clock, timer, start, trigger } = t.context;
 
     timer.schedule(start + 600);
     t.is(clock.next(), start + 500);
@@ -74,7 +74,7 @@ describe('EagerTimer', (it) => {
   });
 
   it('should overwrite a later timer', (t) => {
-    const {clock, timer, start, trigger} = t.context;
+    const { clock, timer, start, trigger } = t.context;
 
     timer.schedule(start + 300);
     timer.schedule(start + 200);
@@ -84,7 +84,7 @@ describe('EagerTimer', (it) => {
   });
 
   it('should overwrite a later timer after a delay', (t) => {
-    const {clock, timer, start, trigger} = t.context;
+    const { clock, timer, start, trigger } = t.context;
 
     timer.schedule(start + 300);
     clock.tick(5);
@@ -96,7 +96,7 @@ describe('EagerTimer', (it) => {
   });
 
   it('should not overwrite an earlier timer', (t) => {
-    const {clock, timer, start, trigger} = t.context;
+    const { clock, timer, start, trigger } = t.context;
 
     timer.schedule(start + 20);
     timer.schedule(start + 300);
@@ -106,7 +106,7 @@ describe('EagerTimer', (it) => {
   });
 
   it('should not overwrite an earlier timer with the maximum delay', (t) => {
-    const {clock, timer, start, trigger} = t.context;
+    const { clock, timer, start, trigger } = t.context;
 
     timer.schedule(start + 20);
     timer.schedule(start + 1000);
@@ -116,7 +116,7 @@ describe('EagerTimer', (it) => {
   });
 
   it('should trigger after the maximum delay for negative times', (t) => {
-    const {clock, timer, start, trigger} = t.context;
+    const { clock, timer, start, trigger } = t.context;
 
     timer.schedule(-1);
     t.is(clock.next(), start + 500);
@@ -124,7 +124,7 @@ describe('EagerTimer', (it) => {
   });
 
   it('should trigger after the maximum delay on null', (t) => {
-    const {clock, timer, start, trigger} = t.context;
+    const { clock, timer, start, trigger } = t.context;
 
     timer.schedule(null);
     t.is(clock.next(), start + 500);
@@ -132,7 +132,7 @@ describe('EagerTimer', (it) => {
   });
 
   it('should trigger after the maximum delay on undefined', (t) => {
-    const {clock, timer, start, trigger} = t.context;
+    const { clock, timer, start, trigger } = t.context;
 
     timer.schedule(undefined);
     t.is(clock.next(), start + 500);
@@ -140,7 +140,7 @@ describe('EagerTimer', (it) => {
   });
 
   it('should trigger after the maximum delay on NaN', (t) => {
-    const {clock, timer, start, trigger} = t.context;
+    const { clock, timer, start, trigger } = t.context;
 
     timer.schedule(NaN);
     t.is(clock.next(), start + 500);
@@ -148,7 +148,7 @@ describe('EagerTimer', (it) => {
   });
 
   it('should not overwrite an earlier timer on null', (t) => {
-    const {clock, timer, start, trigger} = t.context;
+    const { clock, timer, start, trigger } = t.context;
 
     timer.schedule(start + 20);
     timer.schedule(null);
@@ -158,7 +158,7 @@ describe('EagerTimer', (it) => {
   });
 
   it('should trigger immediately for passed timestamps', (t) => {
-    const {clock, timer, start, trigger} = t.context;
+    const { clock, timer, start, trigger } = t.context;
 
     timer.schedule(start - 5);
     t.true(trigger.calledOnce);
@@ -166,7 +166,7 @@ describe('EagerTimer', (it) => {
   });
 
   it('should not trigger after stopping', (t) => {
-    const {clock, timer, start, trigger} = t.context;
+    const { clock, timer, start, trigger } = t.context;
 
     timer.schedule(start + 50);
     clock.tick(25);
@@ -176,7 +176,7 @@ describe('EagerTimer', (it) => {
   });
 
   it('should not schedule immediately after stopping', (t) => {
-    const {clock, timer, start, trigger} = t.context;
+    const { clock, timer, start, trigger } = t.context;
 
     timer.schedule(start + 50);
     clock.tick(25);
@@ -187,7 +187,7 @@ describe('EagerTimer', (it) => {
   });
 
   it('should not schedule later after stopping', (t) => {
-    const {clock, timer, start, trigger} = t.context;
+    const { clock, timer, start, trigger } = t.context;
 
     timer.schedule(start + 50);
     clock.tick(25);
@@ -198,7 +198,7 @@ describe('EagerTimer', (it) => {
   });
 
   it('should fail on invalid maximum delays', (t) => {
-    const {EagerTimer} = t.context;
+    const { EagerTimer } = t.context;
 
     t.throws(() => new EagerTimer(-1), /positive integer/i);
     t.throws(() => new EagerTimer(NaN), /positive integer/i);

--- a/test/eager-timer-test.js
+++ b/test/eager-timer-test.js
@@ -45,6 +45,11 @@ describe('EagerTimer', (it) => {
     Object.assign(t.context, { EagerTimer, timer, clock, start, trigger });
   });
 
+  it('validates its parameter', (t) => {
+    const EagerTimer = require('../lib/eager-timer');
+    t.throws(() => new EagerTimer(-1), TypeError);
+  });
+
   it('should trigger in the future', (t) => {
     const { clock, timer, start, trigger } = t.context;
 

--- a/test/helpers-test.js
+++ b/test/helpers-test.js
@@ -1,8 +1,8 @@
-import {describe} from 'ava-spec';
+import { describe } from 'ava-spec';
 
 import sinon from 'sinon';
 
-import {delay, finallyRejectsWithInitial} from '../lib/helpers';
+import { delay, finallyRejectsWithInitial } from '../lib/helpers';
 
 const mark = () =>
   ((start) => () =>

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,30 @@
+const { delay, waitOn, deferred } = require('promise-callbacks');
+
+// A promise-based barrier.
+function reef(n = 1) {
+  let next;
+  const done = new Promise((resolve) => {
+    next = () => {
+      --n;
+      if (n < 0) return false;
+      if (n === 0) resolve();
+      return true;
+    };
+  });
+  return { done, next };
+}
+
+async function delKeys(client, pattern) {
+  const keys = await client.keys(pattern);
+  if (keys.length) {
+    await client.del(keys);
+  }
+}
+
+module.exports = {
+  reef,
+  delKeys,
+  deferred,
+  delay,
+  waitOn,
+};

--- a/test/job-test.js
+++ b/test/job-test.js
@@ -1,16 +1,23 @@
-import {describe} from 'ava-spec';
+import { describe } from 'ava-spec';
 
 import Job from '../lib/job';
 import Queue from '../lib/queue';
-import helpers from '../lib/helpers';
 
-import {promisify} from 'promise-callbacks';
+const hasOwnProperty = Object.prototype.hasOwnProperty;
+
+// TODO: FLUSHDB instead?
+async function clearKeys(client, queue) {
+  const keys = await client.keys(queue.toKey('*'));
+  if (keys.length) {
+    await client.del(keys);
+  }
+}
 
 describe('Job', (it) => {
   const redisUrl = process.env.BEE_QUEUE_TEST_REDIS;
 
-  const data = {foo: 'bar'};
-  const options = {test: 1};
+  const data = { foo: 'bar' };
+  const options = { test: 1 };
 
   let uid = 0;
 
@@ -27,55 +34,50 @@ describe('Job', (it) => {
 
     await queue.ready();
 
-    Object.assign(t.context, {queue, makeJob});
+    Object.assign(t.context, { queue, makeJob });
   });
 
-  it.afterEach.cb((t) => {
-    const {queue} = t.context;
-    clearKeys(queue.client, queue, t.end);
+  it.afterEach((t) => {
+    const { queue } = t.context;
+    return clearKeys(queue.client, queue);
   });
 
   it('creates a job', async (t) => {
-    const {makeJob} = t.context;
+    const { makeJob } = t.context;
 
     const job = await makeJob();
     t.truthy(job, 'fails to return a job');
-    t.true(helpers.has(job, 'id'), 'job has no id');
-    t.true(helpers.has(job, 'data'), 'job has no data');
+    t.true(hasOwnProperty.call(job, 'id'), 'job has no id');
+    t.true(hasOwnProperty.call(job, 'data'), 'job has no data');
   });
 
   it('creates a job without data', async (t) => {
-    const {queue} = t.context;
+    const { queue } = t.context;
 
     const job = await queue.createJob().save();
     t.deepEqual(job.data, {});
   });
 
-  it.cb('should save with a callback', (t) => {
-    const {queue} = t.context;
-    queue.createJob().save(t.end);
-  });
-
   it.describe('Chaining', (it) => {
     it('sets retries', (t) => {
-      const {queue} = t.context;
+      const { queue } = t.context;
 
-      const job = queue.createJob({foo: 'bar'}).retries(2);
+      const job = queue.createJob({ foo: 'bar' }).retries(2);
       t.is(job.options.retries, 2);
     });
 
     it('rejects invalid retries count', (t) => {
-      const {queue} = t.context;
+      const { queue } = t.context;
 
       t.throws(() => {
-        queue.createJob({foo: 'bar'}).retries(-1);
+        queue.createJob({ foo: 'bar' }).retries(-1);
       }, 'Retries cannot be negative');
     });
 
     it('should reject invalid delay timestamps', (t) => {
-      const {queue} = t.context;
+      const { queue } = t.context;
 
-      const job = queue.createJob({foo: 'bar'});
+      const job = queue.createJob({ foo: 'bar' });
       t.notThrows(() => job.delayUntil(new Date(Date.now() + 10000)));
       t.notThrows(() => job.delayUntil(Date.now() + 10000));
       t.throws(() => job.delayUntil(null), /timestamp/i);
@@ -85,36 +87,36 @@ describe('Job', (it) => {
     });
 
     it('should not save a delay to a past date', (t) => {
-      const {queue} = t.context;
+      const { queue } = t.context;
 
-      const job = queue.createJob({foo: 'bar'});
+      const job = queue.createJob({ foo: 'bar' });
       const until = Date.now() - 1000;
       job.delayUntil(until);
       t.not(job.options.delay, until);
     });
 
     it('sets timeout', (t) => {
-      const {queue} = t.context;
+      const { queue } = t.context;
 
-      const job = queue.createJob({foo: 'bar'}).timeout(5000);
+      const job = queue.createJob({ foo: 'bar' }).timeout(5000);
       t.is(job.options.timeout, 5000);
     });
 
     it('rejects invalid timeout', (t) => {
-      const {queue} = t.context;
+      const { queue } = t.context;
 
       t.throws(() => {
-        queue.createJob({foo: 'bar'}).timeout(-1);
+        queue.createJob({ foo: 'bar' }).timeout(-1);
       }, 'Timeout cannot be negative');
     });
 
     it('saves the job in redis', async (t) => {
-      const {queue, makeJob} = t.context;
+      const { queue, makeJob } = t.context;
 
       const job = await makeJob();
       const storedJob = await Job.fromId(queue, job.id);
       t.truthy(storedJob);
-      t.true(helpers.has(storedJob, 'id'));
+      t.true(hasOwnProperty.call(storedJob, 'id'));
       t.deepEqual(storedJob.data, data);
       t.is(storedJob.options.test, options.test);
     });
@@ -122,17 +124,17 @@ describe('Job', (it) => {
 
   it.describe('Progress', (it) => {
     it('requires a progress value', async (t) => {
-      const {makeJob} = t.context;
+      const { makeJob } = t.context;
 
       const job = await makeJob();
       await t.throws(job.reportProgress(), 'Progress cannot be empty');
     });
 
     it('should support passing a data object', async (t) => {
-      const {makeJob} = t.context;
+      const { makeJob } = t.context;
 
       const job = await makeJob();
-      const progressData = {a: 'value'};
+      const progressData = { a: 'value' };
       return new Promise((resolve) => {
         job.on('progress', (data) => {
           t.deepEqual(data, progressData);
@@ -141,85 +143,50 @@ describe('Job', (it) => {
         job.reportProgress(progressData);
       });
     });
-
-    it.cb('should support callbacks', (t) => {
-      const {makeJob} = t.context;
-
-      makeJob().then((job) => job.reportProgress(50, t.end), t.end);
-    });
   });
 
   it.describe('Remove', (it) => {
     it('removes the job from redis', async (t) => {
-      const {queue, makeJob} = t.context;
-
-      const {hget} = promisify.methods(queue.client, ['hget']);
+      const { queue, makeJob } = t.context;
 
       const job = await makeJob();
       t.is(job, await job.remove());
 
-      t.is(await hget(queue.toKey('jobs'), job.id), null);
-    });
-
-    it('should work with a callback', async (t) => {
-      const {queue, makeJob} = t.context;
-
-      const {hget} = promisify.methods(queue.client, ['hget']);
-
-      const job = await makeJob();
-      const removed = helpers.deferred();
-      job.remove(removed.defer());
-      await removed;
-
-      t.is(await hget(queue.toKey('jobs'), job.id), null);
+      t.is(await queue.client.hget(queue.toKey('jobs'), job.id), null);
     });
   });
 
   it.describe('Retry', (it) => {
-    it.cb('should support callbacks', (t) => {
-      const {makeJob} = t.context;
+    it('should resolve', async (t) => {
+      t.plan(0);
+      const { makeJob } = t.context;
 
-      makeJob().then((job) => job.retry(t.end), t.end);
+      const job = await makeJob();
+      // TODO: actually test something here
+      return job.retry();
     });
   });
 
   it.describe('IsInSet', (it) => {
-    it.cb('should support callbacks', (t) => {
-      const {makeJob} = t.context;
+    it("should reflect the job's state", async (t) => {
+      const { makeJob } = t.context;
 
-      makeJob().then((job) => job.isInSet('stalling', next), t.end);
-
-      function next(err, inSet) {
-        t.ifError(err);
-        t.is(inSet, false);
-        t.end();
-      }
+      const job = await makeJob();
+      const inSet = await job.isInSet('stalling');
+      t.is(inSet, false);
     });
   });
 
   it.describe('fromId', (it) => {
-    it('should support callbacks', async (t) => {
-      const {queue, makeJob} = t.context;
+    it('should fetch a job by its id', async (t) => {
+      const { queue, makeJob } = t.context;
 
       const job = await makeJob();
-      const promise = helpers.deferred();
-      Job.fromId(queue, job.id, promise.defer());
-      const storedJob = await promise;
+      const storedJob = await Job.fromId(queue, job.id);
       t.truthy(storedJob);
-      t.true(helpers.has(storedJob, 'id'));
+      t.true(hasOwnProperty.call(storedJob, 'id'));
       t.deepEqual(storedJob.data, data);
       t.is(storedJob.options.test, options.test);
     });
   });
 });
-
-function clearKeys(client, queue, done) {
-  client.keys(queue.toKey('*'), (err, keys) => {
-    if (err) return done(err);
-    if (keys.length) {
-      client.del(keys, done);
-    } else {
-      done();
-    }
-  });
-}

--- a/test/queue-test.js
+++ b/test/queue-test.js
@@ -5,7 +5,7 @@ import Queue from '../lib/queue';
 import helpers from './helpers';
 import sinon from 'sinon';
 
-import redis from '../lib/redis';
+import * as redis from '../lib/redis';
 import Redis from 'ioredis';
 
 async function recordUntil(emitter, trackedEvents, lastEvent) {
@@ -1506,8 +1506,7 @@ describe('Queue', (it) => {
         jobs.push(queue.createJob({ count: i }));
       }
 
-      // Save all the jobs.
-      await Promise.all(jobs.map((job) => job.save()));
+      await queue.saveAll(jobs);
 
       return end;
     });
@@ -1792,7 +1791,7 @@ describe('Queue', (it) => {
       ];
 
       // Save the three jobs.
-      await Promise.all(jobs.map((job) => job.save()));
+      await queue.saveAll(jobs);
 
       // Artificially move to active.
       await queue._getNextJob();
@@ -1822,7 +1821,7 @@ describe('Queue', (it) => {
       );
 
       // Save the jobs.
-      await Promise.all(jobs.map((job) => job.save()));
+      await queue.saveAll(jobs);
 
       // Artificially move to active.
       await queue._getNextJob();
@@ -1890,7 +1889,7 @@ describe('Queue', (it) => {
       }
 
       // Save all the jobs.
-      await Promise.all(jobs.map((job) => job.save()));
+      await deadQueue.saveAll(jobs);
 
       const { done: resume, next: spooled } = helpers.reef();
       deadQueue.process(concurrency, () => {

--- a/test/queue-test.js
+++ b/test/queue-test.js
@@ -465,7 +465,6 @@ describe('Queue', (it) => {
           quitCommandClient: true,
         });
 
-        // TODO: have Queue#close wait for the queue to close, perhaps?
         // TODO: also pretend the quit worked if there was an NR_CLOSED
         // https://github.com/NodeRedis/node-redis/blob/0041e3e53d5292b13d96ce076653c5b91b314fda/lib/individualCommands.js#L84
         await queue.close();
@@ -1282,7 +1281,7 @@ describe('Queue', (it) => {
       const jobs = errors.map((error) => queue.createJob({ error }));
       const afterFailed = jobs.map((job) => helpers.waitOn(job, 'failed'));
 
-      await Promise.all(jobs.map((job) => job.save()));
+      await queue.saveAll(jobs);
       await Promise.all(afterFailed);
 
       // Force getJobs to fetch fresh copies of the jobs.

--- a/test/redis-test.js
+++ b/test/redis-test.js
@@ -1,0 +1,13 @@
+import { describe } from 'ava-spec';
+
+import * as redis from '../lib/redis';
+import Redis from 'ioredis';
+
+// Fake NodeRedis implementation.
+class RedisClient {}
+
+describe('redis', (it) => {
+  it('should bail on NodeRedis instances', async (t) => {
+    await t.throws(redis.createClient(new RedisClient()), TypeError);
+  });
+});


### PR DESCRIPTION
I took #112 and rebased it against the default branch - phew!

I probably preserved way more of the individual commits than I needed to :grin: (edit: still reachable from 6693a0c7816b8152368bde3ef0a1188095d834a1)

Blocking TODOs:

- [ ] update README
- [ ] fix code coverage
- [x] provide some usability guidance if attempting to pass in a node_redis client
- [x] validate ioredis client abort and quit behaviors
- [ ] figure out whether we need to break anything to address #189 - likely will want to change defaults

Might release this as a 2.0 alpha so our friends over @mixmaxhq can evaluate it in wild, if they're willing.

@LewisJEllis had some fantastic ideas about next steps in #112, and I look forward to pursuing them after we've landed the simplest possible 2.0 that prevents further breakage.

I'll post a review ~in a minute~ eventually that calls out some concerns.

See also #104. Fixes #16 and closes #21.