### PR TITLE
Feat | Job | Store progress with the whole job data

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -36,6 +36,7 @@ class Job extends Emitter {
     data = JSON.parse(data);
     const job = new Job(queue, jobId, data.data, data.options);
     job.status = data.status;
+    job.progress = data.progress;
     return job;
   }
 
@@ -44,6 +45,7 @@ class Job extends Emitter {
       data: this.data,
       options: this.options,
       status: this.status,
+      progress: this.progress,
     });
   }
 


### PR DESCRIPTION
## Problem

We have multiple API instances adding bee-queue jobs.
Our workers call `Job#reportProgress` for long term jobs.
Depending on the API intance handling the call, it might not have the progress update.

## Solution

I added the progress to the stored job data, same place as the status.
It ensures that the progress is saved properly, and that it is not `0` on a consumer recovering the job from redis.


I hope that it's mergable for you, and if so, I would like to know when a release with this feature is possible, so I know if a fork is needed for my project.