### PR TITLE
docs: fix readme typo and clarify use of `setId()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -737,7 +737,7 @@ const job = await queue.createJob({...})
   .save();
 ```
 
-Explicitly sets the ID of the job. If a job with the given ID already exists, the Job will not be created, and `job.id` will be set to `null`. This method can be used to run a once for each of an external resource by passing that resource's ID. For instance, you might run the setup job for a user only once by setting the job ID to the ID of the user.
+Explicitly sets the ID of the job. If a job with the given ID already exists, the Job will not be created, and `job.id` will be set to `null`. This method can be used to run a job once for each of an external resource by passing that resource's ID. For instance, you might run the setup job for a user only once by setting the job ID to the ID of the user. Furthermore, when this feature is used with queue settings `removeOnSuccess: true` and `removeOnFailure: true`, it will allow that job to be re-run again, effectively ensuring that jobId will have a global concurrency of 1.
 
 Avoid passing a numeric job ID, as it may conflict with an auto-generated ID.
 


### PR DESCRIPTION
A small readme update to clarify use cases for `setId(true)`. Also fixes a minor typo.