### PR TITLE
use redis 3 for tls

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -31,7 +31,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [4.0.x, 8.x, 10.x, 12.x, 14.x]
+        node-version: [8.x, 10.x, 12.x, 14.x]
         include:
           - node-version: 14.x
             report-coverage: true

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ jspm_packages
 .DS_Store
 *.sublime-workspace
 notes.txt
+
+#IntelliJ
+.idea

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "p-finally": "^1.0.0",
     "promise-callbacks": "^3.8.1",
-    "redis": "^2.7.1"
+    "redis": "^3.1.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",


### PR DESCRIPTION
As previously discussed in https://github.com/bee-queue/bee-queue/pull/257
In the interest of security, to utilisize `rediss` over TLS. I noticed dependabot was also complaining about redis too.

It seemed like no progress is being made towards bee-queue 2.0 or using IOredis so this is necessary.

Node 4 support needs to be dropped as a result, but that was EOL in 2018
(Node 8 is also EOL as is 10) https://endoflife.software/programming-languages/server-side-scripting/nodejs