### PR TITLE
workaround

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,6 @@
 /// <reference types="node" />
-/// <reference types="redis" />
 
 import {EventEmitter} from 'events';
-import {ClientOpts, RedisClient} from 'redis';
 
 declare class BeeQueue<T = any> extends EventEmitter {
   name: string;
@@ -88,7 +86,7 @@ declare namespace BeeQueue {
     stallInterval?: number;
     nearTermWindow?: number;
     delayedDebounce?: number;
-    redis?: ClientOpts | RedisClient;
+    redis?: any;
     isWorker?: boolean;
     getEvents?: boolean;
     sendEvents?: boolean;


### PR DESCRIPTION
redis that is imported doesn't have a index.d.ts file, so the type import doesn't work.
I suggest this workaround in order to resolve the TypeScript compiling problem