### PR TITLE
fix(examples): Parse request params as number

### DIFF
--- a/examples/express/web.js
+++ b/examples/express/web.js
@@ -8,8 +8,8 @@ const queue = new Queue('express-example');
 
 app.get('/run/:x/:y', function (req, res) {
   const job = queue.createJob({
-    x: req.params.x,
-    y: req.params.y,
+    x: parseInt(req.params.x),
+    y: parseInt(req.params.y),
   });
 
   job.on('succeeded', function (result) {


### PR DESCRIPTION
Initially, they were parsed as strings, and thus the result was '23' instead of 5.