### PR TITLE
feat: added a typecheck to prevent further errors

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -19,13 +19,17 @@ class Job extends Emitter {
 
   static fromId(queue, jobId, cb) {
     const promise = queue
-      ._commandable()
-      .then((client) =>
-        helpers.callAsync((done) =>
-          client.hget(queue.toKey('jobs'), jobId, done)
+        ._commandable()
+        .then((client) =>
+            helpers.callAsync((done) => {
+              if (typeof jobId === 'string' || typeof jobId === 'number') {
+                return client.hget(queue.toKey('jobs'), jobId, done);
+              } else {
+                return done(new Error('jobId must be a string'));
+              }
+            })
         )
-      )
-      .then((data) => (data ? Job.fromData(queue, jobId, data) : null));
+        .then((data) => (data ? Job.fromData(queue, jobId, data) : null));
 
     if (cb) helpers.asCallback(promise, cb);
     return promise;


### PR DESCRIPTION
I was using bee-queue and I just realised a stupid mistake I made after long time of research. A more descriptive error would save me a lot of time.

JobId can only be number or string and in a node.js project it is really easy to pass `null` or even an object as an argument. Maybe this can save some other peoples time. 
If you pass any other argument other then string/number you get a generic error from redis-client which is not super helpful.


![Screenshot 2024-02-16 at 22 16 22](https://github.com/bee-queue/bee-queue/assets/15941813/8101b0b4-879c-4650-af58-0d4ca8d9c2e0)
