### PR TITLE
Fixes issue (uncaught exception) crashing node

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -137,6 +137,9 @@ class Queue extends Emitter {
             setImmediate(() => this.emit('ready'));
             resolve(this._isReady);
             return this;
+          })
+          .catch(err => {
+            reject(err)
           });
       } catch (err) {
         reject(err);


### PR DESCRIPTION
Without catching the promise chain HERE, even with proper user-land exception handling, there is no way to properly catch it. This results in an uncaught exception that crashes node.

See here for more info: (Uncaught Exception, even with Try Catch)[https://stackoverflow.com/questions/79200499/uncaught-exception-even-with-try-catch]

Example:

```javascript
process.on("uncaughtException", uncaughtExceptionListener)

start().catch(console.error)

async function start() {
  try {
    await queue.connect()
  } catch (err) {
    return console.error('Some Error:', err.message)
  }
}

// queue.connect in class
async function connect() {
  try {
    // The next line is where the error originates
    await client.connect()
    return console.log('Never makes it here')
  } catch (err) {
    // Never makes it here either
    return console.error('[client] Connection failed!')
  }
}
````

Output:
```shell
node:internal/process/promises:391
    triggerUncaughtException(err, true /* fromPromise */);
    ^

Error: connect ECONNREFUSED 127.0.0.1:6090
```

The result is that the entire user application crashes, with no way to recover.