### PR TITLE
add notes in docs to inform people latest version of node_redis is not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,9 +338,9 @@ The `settings` fields are:
   - `port`: number, Redis port.
   - `socket`: string, Redis socket to be used instead of a host and port.
 
-Note that this can also be a node_redis `RedisClient` instance, in which case Bee-Queue will issue normal commands over it. It will `duplicate()` the client for blocking commands and PubSub subscriptions, if enabled. This is advanced usage.
+  Note that this can also be a node_redis `RedisClient` instance, in which case Bee-Queue will issue normal commands over it. It will `duplicate()` the client for blocking commands and PubSub subscriptions, if enabled. This is advanced usage.
 
-> Ensure you are using v3 of node_redis since we do not support v4 at this time. 
+  > Ensure you are using v3 of node_redis since we do not support v4 at this time. 
 
 - `isWorker`: boolean. Disable if this queue will not process jobs.
 - `getEvents`: boolean. Disable if this queue does not need to receive job events.

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ By default, every time you create a queue instance with `new Queue()` a new redi
 
 Let's say for example you have a web application with 30 producer queues and you run 10 webservers & 10 worker servers, each one with 4 processes/server. With the default settings this is going to add up to a lot of Redis connections. Each Redis connection consumes a fairly large chunk of memory, and it adds up quickly!
 
-The producer queues are the ones that run on the webserver and they push jobs into the queue. These queues do not need to receive events so they can all share one redis connection by passing in an instance of [node_redis `RedisClient`](https://github.com/NodeRedis/node_redis#rediscreateclient).
+The producer queues are the ones that run on the webserver and they push jobs into the queue. These queues do not need to receive events so they can all share one redis connection by passing in an instance of [node_redis `RedisClient`](https://github.com/NodeRedis/node_redis#rediscreateclient). Note at this time we do not support the latest version (v4) and you must use v3.x
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ The `settings` fields are:
   - `port`: number, Redis port.
   - `socket`: string, Redis socket to be used instead of a host and port.
 
-  Note that this can also be a node_redis `RedisClient` instance, in which case Bee-Queue will issue normal commands over it. It will `duplicate()` the client for blocking commands and PubSub subscriptions, if enabled. This is advanced usage,
+  Note that this can also be a node_redis `RedisClient` instance, in which case Bee-Queue will issue normal commands over it. It will `duplicate()` the client for blocking commands and PubSub subscriptions, if enabled. This is advanced usage. Ensure you are using v3 of node_redis since we do not suppor the latest v4 at this time. 
 
 - `isWorker`: boolean. Disable if this queue will not process jobs.
 - `getEvents`: boolean. Disable if this queue does not need to receive job events.

--- a/README.md
+++ b/README.md
@@ -338,7 +338,9 @@ The `settings` fields are:
   - `port`: number, Redis port.
   - `socket`: string, Redis socket to be used instead of a host and port.
 
-  Note that this can also be a node_redis `RedisClient` instance, in which case Bee-Queue will issue normal commands over it. It will `duplicate()` the client for blocking commands and PubSub subscriptions, if enabled. This is advanced usage. Ensure you are using v3 of node_redis since we do not suppor the latest v4 at this time. 
+Note that this can also be a node_redis `RedisClient` instance, in which case Bee-Queue will issue normal commands over it. It will `duplicate()` the client for blocking commands and PubSub subscriptions, if enabled. This is advanced usage.
+
+> Ensure you are using v3 of node_redis since we do not support v4 at this time. 
 
 - `isWorker`: boolean. Disable if this queue will not process jobs.
 - `getEvents`: boolean. Disable if this queue does not need to receive job events.


### PR DESCRIPTION
I don't want others to waste time debugging something like myself and so many other people have done, because they're not made aware of a pretty large caveat. 

i know there's a discussion and issue created but this info imo should live next to where most people will be tripped up by it, not burried in issues. 

https://github.com/bee-queue/bee-queue/issues/481