### PR TITLE
fix: correct off-by-one in getJobs default end index

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -387,7 +387,7 @@ class Queue extends Emitter {
    * @param {Number=} page.start Start of query range for waiting/active/delayed
    *   queue types. Defaults to 0.
    * @param {Number=} page.end End of query range for waiting/active/delayed
-   *   queue types. Defaults to 100.
+   *   queue types. Defaults to 99.
    * @param {Number=} page.size Number jobs to return for failed/succeeded (SET)
    *   types. Defaults to 100.
    * @param {Function=} callback Called with the equivalent of the returned
@@ -404,7 +404,7 @@ class Queue extends Emitter {
       {
         size: 100,
         start: 0,
-        end: 100,
+        end: 99,
       },
       page
     );


### PR DESCRIPTION
## Problem

`Queue#getJobs` defaults to `{ start: 0, end: 100 }` for list/sorted-set
queue types (`waiting`, `active`, `delayed`). Both Redis `LRANGE` and
`ZRANGE` use **inclusive** bounds, so this call:

```
lrange key 0 100
```

returns **101** elements (indices 0 through 100 inclusive), not 100.

This is inconsistent with the `size: 100` default used for the set-based
queue types (`failed`, `succeeded`), where the intent is clearly to return
at most 100 jobs by default.

## Fix

Change the default `end` from `100` to `99` so that a no-argument
`getJobs('waiting')` call returns at most 100 jobs, matching the behaviour
of `getJobs('failed')` and the documented intent.

Callers who pass an explicit `page.end` are unaffected.