### PR TITLE
fix: use nullish coalescing for job data and options defaults

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -10,10 +10,10 @@ class Job extends Emitter {
     this.queue = queue;
     this.id = jobId;
     this.progress = 0;
-    this.data = data || {};
-    this.options = options || {};
-    this.options.timestamp = this.options.timestamp || Date.now();
-    this.options.stacktraces = this.options.stacktraces || [];
+    this.data = data ?? {};
+    this.options = options ?? {};
+    this.options.timestamp = this.options.timestamp ?? Date.now();
+    this.options.stacktraces = this.options.stacktraces ?? [];
     this.status = 'created';
   }
 


### PR DESCRIPTION
## What

`Job` constructor uses `||` to supply defaults for `data`, `options`, `options.timestamp`, and `options.stacktraces`. This silently replaces any falsy-but-valid value with the default:

```js
this.data = data || {};           // data=false → {}; data=0 → {}; data='' → {}
this.options = options || {};
this.options.timestamp = this.options.timestamp || Date.now();  // timestamp=0 → Date.now()
this.options.stacktraces = this.options.stacktraces || [];
```

A queue consumer that stores boolean flags, numeric codes, or empty strings as job data loses the payload silently.

## Fix

Replace `||` with `??` so only `null` and `undefined` fall through to the default:

```js
this.data = data ?? {};
this.options = options ?? {};
this.options.timestamp = this.options.timestamp ?? Date.now();
this.options.stacktraces = this.options.stacktraces ?? [];
```

## Reproduction

```js
const job = queue.createJob(false);
await job.save();
// job.data is {} instead of false
```